### PR TITLE
Issue #113: Support for PropertyDataFetcher behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,17 @@ Then on the data class:
 4. `method getField<Name>(*fieldArgs [, DataFetchingEnvironment])`
 5. `field <name>`
 
+Last of all, if the data class implements`java.util.Map` then:
+1. `method get(name)`
+
+
 *Note:* All reflection discovery is done on startup, and runtime reflection method calls use [reflectasm](https://github.com/EsotericSoftware/reflectasm), which increases performance and unifies stacktraces.  No more `InvocationTargetException`!
 
 *Note:* `java.util.Optional` can be used for nullable field arguments and nullable return values, and the schema parser will verify that it's not used with non-null field arguments and return values.
 
 *Note:* Methods on `java.lang.Object` are excluded from method matching, for example a field named `class` will require a method named `getFieldClass` defined.
+
+*Note:* If one of the values of a type backed by a `java.util.Map` is non-scalar then this type will need to be added to the `type dictionary` (see below). After adding this type to the dictionary, GraphQL Java Tools will however still be able to find the types used in the fields of this added type.
 
 ### Enum Types
 

--- a/src/main/kotlin/com/coxautodev/graphql/tools/FieldResolverScanner.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/FieldResolverScanner.kt
@@ -67,6 +67,10 @@ internal class FieldResolverScanner(val options: SchemaParserOptions) {
             }
         }
 
+        if(java.util.Map::class.java.isAssignableFrom(search.type.unwrap())) {
+            return PropertyMapResolver(field, search, options, search.type.unwrap())
+        }
+
         return null
     }
 

--- a/src/main/kotlin/com/coxautodev/graphql/tools/PropertyFieldResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/PropertyFieldResolver.kt
@@ -14,7 +14,13 @@ internal class PropertyFieldResolver(field: FieldDefinition, search: FieldResolv
     }
 
     override fun scanForMatches(): List<TypeClassMatcher.PotentialMatch> {
-        return listOf(TypeClassMatcher.PotentialMatch.returnValue(field.type, property.genericType, genericType, SchemaClassScanner.FieldTypeReference(property), false))
+        return listOf(
+                TypeClassMatcher.PotentialMatch.returnValue(
+                    field.type,
+                    property.genericType,
+                    genericType,
+                    SchemaClassScanner.FieldTypeReference(property.toString()),
+                    false))
     }
 
     override fun toString() = "PropertyFieldResolver{property=$property}"

--- a/src/main/kotlin/com/coxautodev/graphql/tools/PropertyMapResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/PropertyMapResolver.kt
@@ -1,0 +1,45 @@
+package com.coxautodev.graphql.tools
+
+import graphql.language.FieldDefinition
+import graphql.schema.DataFetcher
+import graphql.schema.DataFetchingEnvironment
+import java.lang.reflect.ParameterizedType
+
+/**
+ * @author Nick Weedon
+ *
+ * The PropertyMapResolver implements the Map (i.e. property map) specific portion of the logic within the GraphQL PropertyDataFetcher class.
+ */
+internal class PropertyMapResolver(field: FieldDefinition, search: FieldResolverScanner.Search, options: SchemaParserOptions, relativeTo: JavaType): FieldResolver(field, search, options, relativeTo) {
+
+    var mapGenericValue : JavaType = getMapGenericType(relativeTo)
+
+    fun getMapGenericType(mapClass : JavaType) : JavaType {
+        if(mapClass is ParameterizedType) {
+            return mapClass.actualTypeArguments[1]
+        } else {
+            return Object::class.java
+        }
+    }
+
+    override fun createDataFetcher(): DataFetcher<*> {
+        return PropertyMapResolverDataFetcher(getSourceResolver(), field.name)
+    }
+
+    override fun scanForMatches(): List<TypeClassMatcher.PotentialMatch> {
+        return listOf(TypeClassMatcher.PotentialMatch.returnValue(field.type, mapGenericValue, genericType, SchemaClassScanner.FieldTypeReference(field.name), false))
+    }
+
+    override fun toString() = "PropertyMapResolverDataFetcher{key=${field.name}}"
+}
+
+class PropertyMapResolverDataFetcher(private val sourceResolver: SourceResolver, val key : String): DataFetcher<Any> {
+    override fun get(environment: DataFetchingEnvironment): Any? {
+        val resolvedSourceObject = sourceResolver(environment)
+        if(resolvedSourceObject is Map<*, *>) {
+            return resolvedSourceObject[key]
+        } else {
+            throw RuntimeException("PropertyMapResolverDataFetcher attempt to fetch a field from an object instance that was not a map")
+        }
+    }
+}

--- a/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
+++ b/src/test/kotlin/com/coxautodev/graphql/tools/EndToEndSpec.kt
@@ -18,6 +18,8 @@ fun createSchema() = SchemaParser.newParser()
     .scalars(customScalarUUID, customScalarMap, customScalarId)
     .dictionary("OtherItem", OtherItemWithWrongName::class)
     .dictionary("ThirdItem", ThirdItem::class)
+    .dictionary("ComplexMapItem", ComplexMapItem::class)
+    .dictionary("NestedComplexMapItem", NestedComplexMapItem::class)
     .build()
     .makeExecutableSchema()
 
@@ -62,6 +64,12 @@ type Query {
     # Check it's possible to use field names that correspond to methods on the java.lang.Object class
     class: [Item!]
     hashCode: [Item!]
+
+    propertyHashMapItems: [PropertyHashMapItem!]
+    propertyMapMissingNamePropItems: [PropertyHashMapItem!]
+    propertySortedMapItems: [PropertySortedMapItem!]
+    propertyMapWithComplexItems: [PropertyMapWithComplexItem!]
+    propertyMapWithNestedComplexItems: [PropertyMapWithNestedComplexItem!]
 
     propertyField: String!
     dataFetcherResult: Item!
@@ -144,6 +152,38 @@ type ThirdItem {
     id: Int!
 }
 
+type PropertyHashMapItem {
+    name: String
+    age: Int!
+}
+
+type PropertySortedMapItem {
+    name: String!
+    age: Int!
+}
+
+type ComplexMapItem {
+    id: Int!
+}
+
+type UndiscoveredItem {
+    id: Int!
+}
+
+type NestedComplexMapItem {
+    item: UndiscoveredItem
+}
+
+type PropertyMapWithNestedComplexItem {
+    nested: NestedComplexMapItem!
+    age: Int!
+}
+
+type PropertyMapWithComplexItem {
+    nameId: ComplexMapItem!
+    age: Int!
+}
+
 union OtherUnion = Item | ThirdItem
 
 union NestedUnion = OtherUnion | OtherItem
@@ -167,6 +207,27 @@ val otherItems = mutableListOf(
 
 val thirdItems = mutableListOf(
         ThirdItem(100)
+)
+
+val propetyHashMapItems = mutableListOf(
+        hashMapOf("name" to "bob", "age" to 55)
+)
+
+val propertyMapMissingNamePropItems = mutableListOf(
+        hashMapOf<String, kotlin.Any>("age" to 55)
+)
+
+val propetySortedMapItems = mutableListOf(
+        sortedMapOf("name" to "Arthur", "age" to 76),
+        sortedMapOf("name" to "Jane", "age" to 28)
+)
+
+val propertyMapWithComplexItems = mutableListOf(
+        hashMapOf("nameId" to ComplexMapItem(150), "age" to 72)
+)
+
+val propertyMapWithNestedComplexItems = mutableListOf(
+        hashMapOf("nested" to NestedComplexMapItem(UndiscoveredItem(63)), "age" to 72)
 )
 
 class Query: GraphQLQueryResolver, ListListResolver<String>() {
@@ -200,6 +261,13 @@ class Query: GraphQLQueryResolver, ListListResolver<String>() {
 
     fun getFieldClass() = items
     fun getFieldHashCode() = items
+
+    fun propertyHashMapItems() = propetyHashMapItems
+    fun propertyMapMissingNamePropItems() = propertyMapMissingNamePropItems
+    fun propertySortedMapItems() = propetySortedMapItems
+    fun propertyMapWithComplexItems() = propertyMapWithComplexItems
+    fun propertyMapWithNestedComplexItems() = propertyMapWithNestedComplexItems
+
 
     private val propertyField = "test"
 
@@ -256,6 +324,9 @@ enum class Type { TYPE_1, TYPE_2 }
 data class Item(val id: Int, override val name: String, override val type: Type, override val uuid:UUID, val tags: List<Tag>) : ItemInterface
 data class OtherItemWithWrongName(val id: Int, override val name: String, override val type: Type, override val uuid:UUID) : ItemInterface
 data class ThirdItem(val id: Int)
+data class ComplexMapItem(val id: Int)
+data class UndiscoveredItem(val id: Int)
+data class NestedComplexMapItem(val item: UndiscoveredItem)
 data class Tag(val id: Int, val name: String)
 data class ItemSearchInput(val name: String)
 data class NewItemInput(val name: String, val type: Type)


### PR DESCRIPTION
* Added an additional field resolver and logic to recognize java.util.Map based objects as property maps.
* Fixed issue where presence of a type in the type dictionary did not
allow non-scalar map types to be resolved.
* Updated documentation with respect to how fields are resolved.