### PR TITLE
Add test jar, to be shared with others

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -208,6 +208,18 @@
                     <generateReleasePoms>false</generateReleasePoms>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>test-jar</id>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Add the test-jar to the maven project, so others can take advantage of some test helpers, like `Util.assertNoGraphQlErrors`.  This is automatically attached to the build, so will be deployed to Maven Central.