### PR TITLE
added startCursor and endCursor fields to PageInfo graphql type

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/relay/RelayConnectionFactory.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/relay/RelayConnectionFactory.kt
@@ -71,6 +71,8 @@ class RelayConnectionFactory : TypeDefinitionFactory {
                     .name("PageInfo")
                     .fieldDefinition(FieldDefinition("hasPreviousPage", NonNullType(TypeName("Boolean"))))
                     .fieldDefinition(FieldDefinition("hasNextPage", NonNullType(TypeName("Boolean"))))
+                    .fieldDefinition(FieldDefinition("startCursor", TypeName("String")))
+                    .fieldDefinition(FieldDefinition("endCursor", TypeName("String")))
                     .build()
 
     private fun Directive.forTypeName(): String {

--- a/src/test/java/com/coxautodev/graphql/tools/RelayConnectionTest.java
+++ b/src/test/java/com/coxautodev/graphql/tools/RelayConnectionTest.java
@@ -44,6 +44,8 @@ public class RelayConnectionTest {
                         "       pageInfo {\n" +
                         "           hasPreviousPage,\n" +
                         "           hasNextPage\n" +
+                        "           startCursor\n" +
+                        "           endCursor\n" +
                         "       }\n" +
                         "   }\n" +
                         "}";


### PR DESCRIPTION
Right now, `PageInfo` type generated by `RelayConnectionFactory` includes only `hasPreviousPage`/`hasNextPage` fields. While not strictly necessary as per the [core spec](https://facebook.github.io/relay/graphql/connections.htm#sec-undefined.PageInfo), they are, indeed, already supported by `graphql-java` (https://github.com/graphql-java/graphql-java/blob/v11.0/src/main/java/graphql/relay/PageInfo.java#L17, https://github.com/graphql-java/graphql-java/blob/v11.0/src/test/resources/thingRelaySchema.graphqls#L8) and used in official Relay examples, the only thing necessary was to expose them in schema.