### PR TITLE
Better detection of map type parameters

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,11 @@
             <version>11.0</version>
         </dependency>
         <dependency>
+            <groupId>com.fasterxml</groupId>
+            <artifactId>classmate</artifactId>
+            <version>1.4.0</version>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>${jackson.version}</version>

--- a/src/main/kotlin/com/coxautodev/graphql/tools/GenericType.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/GenericType.kt
@@ -1,5 +1,6 @@
 package com.coxautodev.graphql.tools
 
+import com.fasterxml.classmate.ResolvedType
 import com.google.common.primitives.Primitives
 import org.apache.commons.lang3.reflect.TypeUtils
 import sun.reflect.generics.reflectiveObjects.ParameterizedTypeImpl
@@ -130,6 +131,14 @@ internal open class GenericType(protected val mostSpecificType: JavaType, protec
                 is ParameterizedType -> {
                     val actualTypeArguments = type.actualTypeArguments.map { replaceTypeVariable(it) }.toTypedArray()
                     ParameterizedTypeImpl.make(type.rawType as Class<*>?, actualTypeArguments, type.ownerType)
+                }
+                is ResolvedType -> {
+                    if (type.typeParameters.isEmpty()) {
+                        type.erasedType
+                    } else {
+                        val actualTypeArguments = type.typeParameters.map { replaceTypeVariable(it) }.toTypedArray()
+                        ParameterizedTypeImpl.make(type.erasedType, actualTypeArguments, null)
+                    }
                 }
                 is TypeVariable<*> -> {
                     if (declaringType is ParameterizedType) {

--- a/src/main/kotlin/com/coxautodev/graphql/tools/PropertyMapResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/PropertyMapResolver.kt
@@ -14,10 +14,17 @@ internal class PropertyMapResolver(field: FieldDefinition, search: FieldResolver
 
     var mapGenericValue : JavaType = getMapGenericType(relativeTo)
 
+    /**
+     * Takes a type which implements Map and tries to find the
+     * value type of that map. For some reason, mapClass is losing
+     * its generics somewhere along the way and is always a raw
+     * type
+     */
     fun getMapGenericType(mapClass : JavaType) : JavaType {
         val resolvedType = TypeResolver().resolve(mapClass)
 
-        return resolvedType.typeParametersFor(Map::class.java)[1]
+        val typeParameters = resolvedType.typeParametersFor(Map::class.java)
+        return typeParameters.elementAtOrElse(1) { Object::class.java }
     }
 
     override fun createDataFetcher(): DataFetcher<*> {

--- a/src/main/kotlin/com/coxautodev/graphql/tools/PropertyMapResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/PropertyMapResolver.kt
@@ -1,9 +1,9 @@
 package com.coxautodev.graphql.tools
 
+import com.fasterxml.classmate.TypeResolver
 import graphql.language.FieldDefinition
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
-import java.lang.reflect.ParameterizedType
 
 /**
  * @author Nick Weedon
@@ -14,10 +14,23 @@ internal class PropertyMapResolver(field: FieldDefinition, search: FieldResolver
 
     var mapGenericValue : JavaType = getMapGenericType(relativeTo)
 
+    /**
+     * this impl still has some problems:
+     * - mapClass lost its generics somewhere along the way, so if you had
+     *   something like {@code class Resolver<V> implements Map<String, V>}
+     *   then we won't be able to infer the value type
+     * - this doesn't handle the case of the map value type being generic,
+     *   for example {@code class Resolver implements Map<String, MyType<MyTypeArg>>}
+     */
     fun getMapGenericType(mapClass : JavaType) : JavaType {
-        if(mapClass is ParameterizedType) {
-            return mapClass.actualTypeArguments[1]
+        val resolvedType = TypeResolver().resolve(mapClass)
+
+        val mapValueType = resolvedType.typeParametersFor(Map::class.java)[1]
+        if (mapValueType.typeParameters.isEmpty()) {
+            // no type params should mean regular class
+            return mapValueType.erasedType
         } else {
+            // TODO raise an error? try to handle this case?
             return Object::class.java
         }
     }

--- a/src/main/kotlin/com/coxautodev/graphql/tools/PropertyMapResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/PropertyMapResolver.kt
@@ -14,25 +14,10 @@ internal class PropertyMapResolver(field: FieldDefinition, search: FieldResolver
 
     var mapGenericValue : JavaType = getMapGenericType(relativeTo)
 
-    /**
-     * this impl still has some problems:
-     * - mapClass lost its generics somewhere along the way, so if you had
-     *   something like {@code class Resolver<V> implements Map<String, V>}
-     *   then we won't be able to infer the value type
-     * - this doesn't handle the case of the map value type being generic,
-     *   for example {@code class Resolver implements Map<String, MyType<MyTypeArg>>}
-     */
     fun getMapGenericType(mapClass : JavaType) : JavaType {
         val resolvedType = TypeResolver().resolve(mapClass)
 
-        val mapValueType = resolvedType.typeParametersFor(Map::class.java)[1]
-        if (mapValueType.typeParameters.isEmpty()) {
-            // no type params should mean regular class
-            return mapValueType.erasedType
-        } else {
-            // TODO raise an error? try to handle this case?
-            return Object::class.java
-        }
+        return resolvedType.typeParametersFor(Map::class.java)[1]
     }
 
     override fun createDataFetcher(): DataFetcher<*> {


### PR DESCRIPTION
This PR is a fix for #228. 

As far as I can tell, the `mapClass` getting passed in is never a `ParameterizedType` so `PropertyMapResolver#getMapGenericType` always returns `Object::class.java` (and even if it was generic, the code is looking at the type parameters on the wrong class). This leads to the limitation documented [here](https://www.graphql-java-kickstart.com/tools/schema-definition/):
> Note: If one of the values of a type backed by a java.util.Map is non-scalar then this type will need to be added to the type dictionary (see below).

This PR attempts to fix the issue by using ClassMate to introspect the Map type parameters. This fixes the issue described in #228 and makes map resolvers work without the need to add to the dictionary. 

However, this PR doesn't fix the issue with `mapClass` losing it's generics. This means that the return type of your method can't be Map, otherwise you'll get the previous behavior of detecting `Object::class.java` (to be safe, the return type shouldn't be generic at all). For example, this code gets detected properly and doesn't need to use the dictionary:
```java
public class PropertiesMap implements Map<String, PropertyValue> {}

public PropertiesMap getProperties() {
  return new PropertiesMap(...);
}
```

However this code would detect `Object::class.java` and need to still use the dictionary:
```java
public class PropertiesMap implements Map<String, PropertyValue> {}

public Map<String, PropertyValue> getProperties() {
  return new PropertiesMap(...);
}
```