### PR TITLE
Migrate to graphql-java 12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <dependency>
             <groupId>com.graphql-java</groupId>
             <artifactId>graphql-java</artifactId>
-            <version>11.0</version>
+            <version>12.0</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml</groupId>
@@ -217,6 +217,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
+                <version>3.1.1</version>
                 <executions>
                     <execution>
                         <id>test-jar</id>

--- a/src/main/kotlin/com/coxautodev/graphql/tools/RootTypeInfo.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/RootTypeInfo.kt
@@ -13,9 +13,9 @@ internal class RootTypeInfo private constructor(val queryType: TypeName?, val mu
         const val DEFAULT_SUBSCRIPTION_NAME = "Subscription"
 
         fun fromSchemaDefinitions(definitions: List<SchemaDefinition>): RootTypeInfo {
-            val queryType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "query" }?.type as TypeName?
-            val mutationType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "mutation" }?.type as TypeName?
-            val subscriptionType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "subscription" }?.type as TypeName?
+            val queryType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "query" }?.typeName
+            val mutationType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "mutation" }?.typeName
+            val subscriptionType = definitions.lastOrNull()?.operationTypeDefinitions?.find { it.name == "subscription" }?.typeName
 
             return RootTypeInfo(queryType, mutationType, subscriptionType)
         }

--- a/src/main/kotlin/com/coxautodev/graphql/tools/relay/RelayConnectionFactory.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/relay/RelayConnectionFactory.kt
@@ -6,6 +6,7 @@ import graphql.language.Comment
 import graphql.language.Definition
 import graphql.language.Directive
 import graphql.language.FieldDefinition
+import graphql.language.IgnoredChars
 import graphql.language.ListType
 import graphql.language.NonNullType
 import graphql.language.ObjectTypeDefinition
@@ -87,7 +88,7 @@ class RelayConnectionFactory : TypeDefinitionFactory {
         return this.directives.map { it.withField(this) }
     }
 
-    class DirectiveWithField(val field: FieldDefinition, name: String, arguments: List<Argument>, sourceLocation: SourceLocation, comments: List<Comment>) : Directive(name, arguments, sourceLocation, comments) {
+    class DirectiveWithField(val field: FieldDefinition, name: String, arguments: List<Argument>, sourceLocation: SourceLocation, comments: List<Comment>) : Directive(name, arguments, sourceLocation, comments, IgnoredChars.EMPTY) {
         fun getTypeName(): String {
             val type = field.type
             if (type is NonNullType) {

--- a/src/main/kotlin/graphql/schema/idl/DirectiveBehavior.kt
+++ b/src/main/kotlin/graphql/schema/idl/DirectiveBehavior.kt
@@ -20,7 +20,8 @@ class DirectiveBehavior {
     }
 
     fun onField(element: GraphQLFieldDefinition, params: Params): GraphQLFieldDefinition {
-        return directiveHelper.onField(element, params.toParameters())
+        // noop, since the actual behaviour has moved to onObject/onInterface since graphql-java 12.0
+        return element
     }
 
     fun onInterface(element: GraphQLInterfaceType, params: Params): GraphQLInterfaceType =
@@ -35,17 +36,23 @@ class DirectiveBehavior {
     fun onEnum(element: GraphQLEnumType, params: Params): GraphQLEnumType =
             directiveHelper.onEnum(element, params.toParameters())
 
-    fun onEnumValue(element: GraphQLEnumValueDefinition, params: Params): GraphQLEnumValueDefinition =
-            directiveHelper.onEnumValue(element, params.toParameters())
+    fun onEnumValue(element: GraphQLEnumValueDefinition, params: Params): GraphQLEnumValueDefinition {
+        // noop, since the actual behaviour has moved to onEnum since graphql-java 12.0
+        return element
+    }
 
-    fun onArgument(element: GraphQLArgument, params: Params): GraphQLArgument =
-            directiveHelper.onArgument(element, params.toParameters())
+    fun onArgument(element: GraphQLArgument, params: Params): GraphQLArgument {
+        // noop, since the actual behaviour has moved to onObject/onInterface since graphql-java 12.0
+        return element
+    }
 
     fun onInputObject(element: GraphQLInputObjectType, params: Params): GraphQLInputObjectType =
             directiveHelper.onInputObjectType(element, params.toParameters())
 
-    fun onInputObjectField(element: GraphQLInputObjectField, params: Params): GraphQLInputObjectField =
-            directiveHelper.onInputObjectField(element, params.toParameters())
+    fun onInputObjectField(element: GraphQLInputObjectField, params: Params): GraphQLInputObjectField {
+        // noop, since the actual behaviour has moved to onInputObjectType since graphql-java 12.0
+        return element
+    }
 
     data class Params(val runtimeWiring: RuntimeWiring) {
         internal fun toParameters() = SchemaGeneratorDirectiveHelper.Parameters(null, runtimeWiring, null, null)

--- a/src/test/groovy/com/coxautodev/graphql/tools/MethodFieldResolverDataFetcherSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/MethodFieldResolverDataFetcherSpec.groovy
@@ -8,14 +8,12 @@ import graphql.execution.ExecutionId
 import graphql.execution.ExecutionStrategy
 import graphql.execution.ExecutionStrategyParameters
 import graphql.execution.instrumentation.SimpleInstrumentation
-import graphql.language.BooleanValue
 import graphql.language.FieldDefinition
 import graphql.language.InputValueDefinition
 import graphql.language.NonNullType
 import graphql.language.TypeName
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
-import graphql.schema.DataFetchingEnvironmentBuilder
 import graphql.schema.DataFetchingEnvironmentImpl
 import spock.lang.Specification
 
@@ -213,11 +211,10 @@ class MethodFieldResolverDataFetcherSpec extends Specification {
     }
 
     private static DataFetchingEnvironment createEnvironment(Object context, Object source, Map<String, Object> arguments = [:]) {
-        DataFetchingEnvironmentBuilder.newDataFetchingEnvironment()
+        DataFetchingEnvironmentImpl.newDataFetchingEnvironment(buildExecutionContext())
                 .source(source)
                 .arguments(arguments)
                 .context(context)
-                .executionContext(buildExecutionContext())
                 .build()
     }
 

--- a/src/test/kotlin/com/coxautodev/graphql/tools/MethodFieldResolverDataFetcherTest.kt
+++ b/src/test/kotlin/com/coxautodev/graphql/tools/MethodFieldResolverDataFetcherTest.kt
@@ -8,7 +8,7 @@ import graphql.language.InputValueDefinition
 import graphql.language.TypeName
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
-import graphql.schema.DataFetchingEnvironmentBuilder
+import graphql.schema.DataFetchingEnvironmentImpl
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
@@ -108,11 +108,10 @@ class MethodFieldResolverDataFetcherTest {
     }
 
     private fun createEnvironment(source: Any, arguments: Map<String, Any> = emptyMap(), context: Any? = null): DataFetchingEnvironment {
-        return DataFetchingEnvironmentBuilder.newDataFetchingEnvironment()
+        return DataFetchingEnvironmentImpl.newDataFetchingEnvironment(buildExecutionContext())
                 .source(source)
                 .arguments(arguments)
                 .context(context)
-                .executionContext(buildExecutionContext())
                 .build()
     }
 


### PR DESCRIPTION
These changes migrate graphql-java-tools towards graphql-java 12.0
I have tested the changes on a medium-large schema (containing enums, directives, mutations etc.), and all seems well.

The most problematic change is that the field GraphQLInterfaceType::typeResolver is not accessible anymore (the getter has become package protected and will be removed in future versions of graphql-java). The workaround for now is to use reflection to access it ... 