### PR TITLE
update commons-lang3 version for Java 11 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.8.1</version>
+            <version>3.9</version>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>


### PR DESCRIPTION
I ran into an issue using resolvers with Java 11, and after some debugging I traced the issue to the Apache commons-lang3 library.

This issue only comes up when implementing a `GraphQLResolver` class - root resolvers, etc are fine.

In `ResolverInfo.kt`, the `NormalResolverInfo::findDataClass` method makes a call to `TypeUtils.determineTypeArguments`, which internally hits a NPE - as commons-lang3 3.8 and below improperly create an enum value representing the current Java version.

By upgrading to 3.9 I have had success running my project again.

Thanks, hope this helps!