### PR TITLE
294 handle optional parameters

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
@@ -81,7 +81,7 @@ internal class MethodFieldResolver(field: FieldDefinition, search: FieldResolver
                     null
                 }
 
-                if (value == null && isOptional) {
+                if (value == null && isOptional && environment.containsArgument(definition.name)) {
                     return@add Optional.empty<Any>()
                 }
 


### PR DESCRIPTION
Resolves #294 

The issue describes the problem. This simple fix would make the library more consistent with [graphql-java](https://github.com/graphql-java/graphql-java). It would also allow for easy differentiation between absent and `null` arguments.

`null` -> argument was omitted from the query
`Optional.empty()` -> argument was not omitted and it was set to GraphQL `null`

It makes it possible to use GraphQL `null` in mutations for clearing values without using the `environment.containsArgument` workaround. 