### PR TITLE
294 handle optional parameters fix

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
@@ -81,8 +81,12 @@ internal class MethodFieldResolver(field: FieldDefinition, search: FieldResolver
                     null
                 }
 
-                if (value == null && isOptional && environment.containsArgument(definition.name)) {
-                    return@add Optional.empty<Any>()
+                if (value == null && isOptional) {
+                    if (environment.containsArgument(definition.name)) {
+                        return@add Optional.empty<Any>()
+                    } else {
+                        return@add null;
+                    }
                 }
 
                 return@add mapper.convertValue(value, typeReference)


### PR DESCRIPTION
Resolves #294 and fixes #310 

@oliemansm I apologize, the previous PR contained an error.

In case the argument was omitted the value was `null` and it was passed to Jackson deserializer. The deserializer converts `null` to `Optional.empty()` thus defeating the purpose of the PR.

This fix instead bypasses Jackson completely when the value is `null` and uses Jackson only if the value was actually provided.