### PR TITLE
Update jackson version due to security vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.version>1.8</java.version>
         <kotlin.version>1.3.31</kotlin.version>
         <kotlin-coroutines.version>1.2.1</kotlin-coroutines.version>
-        <jackson.version>2.9.9</jackson.version>
+        <jackson.version>2.10.0</jackson.version>
         <graphql-java.version>13.0</graphql-java.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
There are several security vulnerabilities in jackson-databind. (see details here)
This PR updates to the latest available version of jackson.
