### PR TITLE
Ignore proxies when scanning for field resolvers.

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/FieldResolverScanner.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/FieldResolverScanner.kt
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.reflect.FieldUtils
 import org.slf4j.LoggerFactory
 import java.lang.reflect.Modifier
 import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Proxy
 import java.lang.reflect.Type
 import kotlin.reflect.full.valueParameters
 import kotlin.reflect.jvm.javaType
@@ -25,7 +26,7 @@ internal class FieldResolverScanner(val options: SchemaParserOptions) {
         private val log = LoggerFactory.getLogger(FieldResolverScanner::class.java)
 
         fun getAllMethods(type: JavaType) =
-                (type.unwrap().declaredMethods.toList()
+                (type.unwrap().declaredNonProxyMethods.toList()
                         + ClassUtils.getAllInterfaces(type.unwrap()).flatMap { it.methods.toList() }
                         + ClassUtils.getAllSuperclasses(type.unwrap()).flatMap { it.methods.toList() })
                         .asSequence()

--- a/src/main/kotlin/com/coxautodev/graphql/tools/Utils.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/Utils.kt
@@ -7,6 +7,7 @@ import graphql.language.ObjectTypeDefinition
 import graphql.language.ObjectTypeExtensionDefinition
 import graphql.language.Type
 import java.lang.reflect.ParameterizedType
+import java.lang.reflect.Proxy
 
 /**
  * @author Andrew Potter
@@ -15,6 +16,7 @@ import java.lang.reflect.ParameterizedType
 internal typealias GraphQLRootResolver = GraphQLResolver<Void>
 
 internal typealias JavaType = java.lang.reflect.Type
+internal typealias JavaMethod = java.lang.reflect.Method
 internal typealias GraphQLLangType = graphql.language.Type<*>
 
 internal fun Type<*>.unwrap(): Type<*> = when (this) {
@@ -33,3 +35,11 @@ internal fun JavaType.unwrap(): Class<out Any> =
         } else {
             this as Class<*>
         }
+
+internal val Class<*>.declaredNonProxyMethods: List<JavaMethod>
+    get() {
+        return when {
+            Proxy.isProxyClass(this) -> emptyList()
+            else -> this.declaredMethods.toList()
+        }
+    }


### PR DESCRIPTION
I use java proxies to auto generate resolvers.
But the field resolver complain about the missing generic information.

The problem is, that java proxies declares all interface methods but all generic types are erased.
So the scanning ends with an `Unable to match type definition (...) with java type (interface java.lang.Iterable): Java class is not a List or generic type information was lost: interface java.lang.Iterable` error.
