### PR TITLE
Make coroutine scope configurable via context

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
@@ -12,7 +12,6 @@ import graphql.language.TypeName
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLTypeUtil.isScalar
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
 import java.lang.reflect.Method
 import java.util.Comparator
@@ -194,7 +193,7 @@ open class MethodFieldResolverDataFetcher(private val sourceResolver: SourceReso
         val args = this.args.map { it(environment) }.toTypedArray()
 
         return if (isSuspendFunction) {
-            GlobalScope.future(options.coroutineContextProvider.provide()) {
+            environment.coroutineScope().future(options.coroutineContextProvider.provide()) {
                 methodAccess.invokeSuspend(source, methodIndex, args)?.transformWithGenericWrapper(environment)
             }
         } else {

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParserBuilder.kt
@@ -14,7 +14,6 @@ import graphql.schema.idl.RuntimeWiring
 import graphql.schema.idl.SchemaDirectiveWiring
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.reactive.publish
 import org.antlr.v4.runtime.RecognitionException
@@ -383,8 +382,8 @@ data class SchemaParserOptions internal constructor(
                         GenericWrapper(CompletableFuture::class, 0),
                         GenericWrapper(CompletionStage::class, 0),
                         GenericWrapper(Publisher::class, 0),
-                        GenericWrapper.withTransformer(ReceiveChannel::class, 0, { receiveChannel ->
-                            GlobalScope.publish(coroutineContextProvider.provide()) {
+                        GenericWrapper.withTransformer(ReceiveChannel::class, 0, { receiveChannel, environment ->
+                            environment.coroutineScope().publish(coroutineContextProvider.provide()) {
                                 try {
                                     for (item in receiveChannel) {
                                         send(item)

--- a/src/main/kotlin/com/coxautodev/graphql/tools/Utils.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/Utils.kt
@@ -38,6 +38,6 @@ internal fun JavaType.unwrap(): Class<out Any> =
         }
 
 internal fun DataFetchingEnvironment.coroutineScope(): CoroutineScope {
-    val context: Any = this.getContext()
+    val context: Any? = this.getContext()
     return if (context is CoroutineScope) context else GlobalScope
 }

--- a/src/main/kotlin/com/coxautodev/graphql/tools/Utils.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/Utils.kt
@@ -6,6 +6,9 @@ import graphql.language.NonNullType
 import graphql.language.ObjectTypeDefinition
 import graphql.language.ObjectTypeExtensionDefinition
 import graphql.language.Type
+import graphql.schema.DataFetchingEnvironment
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.GlobalScope
 import java.lang.reflect.ParameterizedType
 
 /**
@@ -33,3 +36,8 @@ internal fun JavaType.unwrap(): Class<out Any> =
         } else {
             this as Class<*>
         }
+
+internal fun DataFetchingEnvironment.coroutineScope(): CoroutineScope {
+    val context: Any = this.getContext()
+    return if (context is CoroutineScope) context else GlobalScope
+}


### PR DESCRIPTION
When using suspending resolvers, graphql-java-tools launches coroutines in the global scope, which makes it impossible to structure concurrency properly. More details on why using `GlobalScope` is not recommended: https://medium.com/@elizarov/the-reason-to-avoid-globalscope-835337445abc.

This PR makes the coroutine scope configurable. This is done by having the GraphQL context implement `CoroutineScope`. It is of course completely optional, `GlobalScope` will still be used by default.

Note: this is different from `coroutineContextProvider` in `SchemaParserOptions`, which does not override the scope, and does not allow having a different scope for each request. A concrete use-case for per-request scopes is to ensure all coroutines spawned by any given request are cancelled after at most 1 minute.