### PR TITLE
Upgrade to graphql-java 14.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <kotlin.version>1.3.31</kotlin.version>
         <kotlin-coroutines.version>1.2.1</kotlin-coroutines.version>
         <jackson.version>2.10.0</jackson.version>
-        <graphql-java.version>13.0</graphql-java.version>
+        <graphql-java.version>14.0</graphql-java.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
@@ -128,8 +128,8 @@ class SchemaParser internal constructor(scanResult: ScannedSchemaObjects, privat
 
         val additionalObjects = objects.filter { o -> o != query && o != subscription && o != mutation }
 
-        @Suppress("UNCHECKED_CAST") val dictionary = (additionalObjects + inputObjects + enums + interfaces + unions).toSet() as Set<GraphQLType>
-        return SchemaObjects(query, mutation, subscription, dictionary, codeRegistryBuilder)
+        val types = (additionalObjects.toSet() as Set<GraphQLType>) + inputObjects + enums + interfaces + unions
+        return SchemaObjects(query, mutation, subscription, types, codeRegistryBuilder)
     }
 
     /**

--- a/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/SchemaParser.kt
@@ -128,7 +128,8 @@ class SchemaParser internal constructor(scanResult: ScannedSchemaObjects, privat
 
         val additionalObjects = objects.filter { o -> o != query && o != subscription && o != mutation }
 
-        return SchemaObjects(query, mutation, subscription, (additionalObjects + inputObjects + enums + interfaces + unions).toSet(), codeRegistryBuilder)
+        @Suppress("UNCHECKED_CAST") val dictionary = (additionalObjects + inputObjects + enums + interfaces + unions).toSet() as Set<GraphQLType>
+        return SchemaObjects(query, mutation, subscription, dictionary, codeRegistryBuilder)
     }
 
     /**


### PR DESCRIPTION
This patch addresses issue #354 . It upgrades graphql-java to version 14, and fixes a compilation problem.