### PR TITLE
Treat array of non-null scalars as scalars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,12 @@
             <version>1.0.2</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
@@ -127,16 +127,12 @@ internal class MethodFieldResolver(field: FieldDefinition, search: FieldResolver
     }
 
     private fun isScalarType(environment: DataFetchingEnvironment, type: Type<*>, genericParameterType: JavaType): Boolean =
-            when {
-                type is ListType ->
-                    List::class.java.isAssignableFrom(this.genericType.getRawClass(genericParameterType))
+            when (type) {
+                is ListType -> List::class.java.isAssignableFrom(this.genericType.getRawClass(genericParameterType))
                         && isScalarType(environment, type.type, this.genericType.unwrapGenericType(genericParameterType))
-                type is TypeName ->
-                    environment.graphQLSchema?.getType(type.name)?.let { isScalar(it) } ?: false
-                type is NonNullType && type.type is TypeName ->
-                    environment.graphQLSchema?.getType((type.type as TypeName).name)?.let { isScalar(unwrapNonNull(it)) } ?: false
-                else ->
-                    false
+                is TypeName -> environment.graphQLSchema?.getType(type.name)?.let { isScalar(it) } ?: false
+                is NonNullType -> isScalarType(environment, type.type, genericParameterType)
+                else -> false
             }
 
     override fun scanForMatches(): List<TypeClassMatcher.PotentialMatch> {

--- a/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
@@ -207,7 +207,7 @@ class EndToEndSpec extends Specification {
             '''
         }
         then:
-        data
+        (data["echoFiles"] as ArrayList<String>).join(",") == "Hello,World"
     }
 
     def "generated schema should handle any java.util.Map (using HashMap) types as property maps"() {

--- a/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
+++ b/src/test/groovy/com/coxautodev/graphql/tools/EndToEndSpec.groovy
@@ -197,6 +197,19 @@ class EndToEndSpec extends Specification {
             data.itemByUUID
     }
 
+    def "generated schema should handle non nullable scalar types"() {
+        when:
+        def fileParts = [new MockPart("test.doc", "Hello"), new MockPart("test.doc", "World")]
+        def args = ["fileParts": fileParts]
+        def data = Utils.assertNoGraphQlErrors( gql,  args) {
+            '''
+              mutation ($fileParts: [Upload!]!) { echoFiles(fileParts: $fileParts)}
+            '''
+        }
+        then:
+        data
+    }
+
     def "generated schema should handle any java.util.Map (using HashMap) types as property maps"() {
         when:
         def data = Utils.assertNoGraphQlErrors(gql) {


### PR DESCRIPTION
This is fix for #240, and test for same issue.

When array of non-nullable scalars is input, an error is thrown from Jackson ObjectMapper. The problem then was, NonNullType was ignored by MethodFieldResolver.isScalarType. Changes in #342 handles NonNullType but it doesn't handle NonNullType.type is ListType.