### PR TITLE
changed default CoroutineScope to not use GlobalScope to avoid potential cancellation issues and other pitfalls

### DIFF
--- a/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/MethodFieldResolver.kt
@@ -13,7 +13,6 @@ import graphql.language.TypeName
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.GraphQLTypeUtil.*
-import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.future.future
 import java.lang.reflect.Method
 import java.util.Comparator

--- a/src/main/kotlin/com/coxautodev/graphql/tools/Utils.kt
+++ b/src/main/kotlin/com/coxautodev/graphql/tools/Utils.kt
@@ -8,7 +8,7 @@ import graphql.language.ObjectTypeExtensionDefinition
 import graphql.language.Type
 import graphql.schema.DataFetchingEnvironment
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.GlobalScope
+import kotlinx.coroutines.Dispatchers
 import java.lang.reflect.Method
 import java.lang.reflect.ParameterizedType
 import java.lang.reflect.Proxy
@@ -44,7 +44,7 @@ internal fun JavaType.unwrap(): Class<out Any> =
 
 internal fun DataFetchingEnvironment.coroutineScope(): CoroutineScope {
     val context: Any? = this.getContext()
-    return if (context is CoroutineScope) context else GlobalScope
+    return if (context is CoroutineScope) context else CoroutineScope(Dispatchers.Default)
 }
 
 internal val Class<*>.declaredNonProxyMethods: List<JavaMethod>


### PR DESCRIPTION
From the [Kotlin docs](https://kotlinlang.org/docs/reference/coroutines/coroutine-context-and-dispatchers.html#children-of-a-coroutine) we read the following _(emphasis added)_:

> When a coroutine is launched in the CoroutineScope of another coroutine, it inherits its context via CoroutineScope.coroutineContext and the Job of the new coroutine becomes a child of the parent coroutine's job. When the parent coroutine is cancelled, all its children are recursively cancelled, too.
>
> **However, when GlobalScope is used to launch a coroutine, there is no parent for the job of the new coroutine. It is therefore not tied to the scope it was launched from and operates independently.**

In order to avoid creating threads that aren't tied to any parent scopes that may exist, `GlobalScope` has been replaced in this PR with just a normal `CoroutineScope` that uses the `Dispatchers.Default` context when no scope is provided via the `DataFetchingEnvironment` context _(I.E. this normal `CoroutineScope` is the default scope)_.