### PR TITLE
Remove reflectasm. Fixes #390

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,11 +105,6 @@
             <version>${jackson.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.esotericsoftware</groupId>
-            <artifactId>reflectasm</artifactId>
-            <version>1.11.9</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
             <version>3.9</version>

--- a/src/test/groovy/graphql/kickstart/tools/EndToEndSpec.groovy
+++ b/src/test/groovy/graphql/kickstart/tools/EndToEndSpec.groovy
@@ -1,5 +1,6 @@
 package graphql.kickstart.tools
 
+import graphql.ExecutionInput
 import graphql.ExecutionResult
 import graphql.GraphQL
 import graphql.execution.AsyncExecutionStrategy
@@ -664,4 +665,17 @@ class EndToEndSpec extends Specification {
         data.arrayItems.collect { it.name } == ['item1', 'item2']
     }
 
+    def "generated schema should re-throw original runtime exception when executing a resolver method"() {
+        when:
+
+        gql.execute(ExecutionInput.newExecutionInput().query('''
+                {
+                    throwsIllegalArgumentException
+                }
+                '''
+        ))
+
+        then:
+        IllegalArgumentException
+    }
 }

--- a/src/test/kotlin/graphql/kickstart/tools/EndToEndSpecHelper.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/EndToEndSpecHelper.kt
@@ -81,6 +81,8 @@ type Query {
     coroutineItems: [Item!]!
 
     arrayItems: [Item!]!
+    
+    throwsIllegalArgumentException: String
 }
 
 type ExtendedType {
@@ -296,6 +298,10 @@ class Query : GraphQLQueryResolver, ListListResolver<String>() {
   suspend fun coroutineItems(): List<Item> = CompletableDeferred(items).await()
 
   fun arrayItems() = items.toTypedArray()
+
+  fun throwsIllegalArgumentException(): String {
+    throw IllegalArgumentException("Expected")
+  }
 }
 
 class UnusedRootResolver : GraphQLQueryResolver


### PR DESCRIPTION
Remove the reflectasm library, which gives warnings on JDK9+ and doesn't seem to be actively maintained anymore. 

For a more in-depth description, see the associated issue: #390