### PR TITLE
Modularize project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 sudo: false
 script:
   - sh travis-build.sh

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <java.version>1.8</java.version>
+        <java.version>1.9</java.version>
         <kotlin.version>1.3.70</kotlin.version>
         <kotlin-coroutines.version>1.2.1</kotlin-coroutines.version>
         <jackson.version>2.10.3</jackson.version>
@@ -148,8 +148,19 @@
         <dependency>
             <groupId>org.spockframework</groupId>
             <artifactId>spock-core</artifactId>
-            <version>1.0-groovy-2.4</version>
+            <version>2.0-M2-groovy-3.0</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>junit</groupId>
+                    <artifactId>junit</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.13</version>
         </dependency>
         <dependency>
             <groupId>cglib</groupId>
@@ -251,10 +262,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.3</version>
+                <version>3.8.1</version>
                 <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
+                    <source>1.9</source>
+                    <target>1.9</target>
                 </configuration>
             </plugin>
 

--- a/src/main/kotlin/module-info.java
+++ b/src/main/kotlin/module-info.java
@@ -1,0 +1,19 @@
+module graphql.kickstart.tools {
+	requires graphql.java;
+	requires kotlin.stdlib;
+	requires com.fasterxml.classmate;
+	requires com.fasterxml.jackson.databind;
+	requires com.fasterxml.jackson.datatype.jdk8;
+
+	exports graphql.kickstart.tools;
+	exports graphql.kickstart.tools.directive;
+	exports graphql.kickstart.tools.proxy;
+	exports graphql.kickstart.tools.relay;
+	exports graphql.kickstart.tools.util;
+
+	opens graphql.kickstart.tools;
+	opens graphql.kickstart.tools.directive;
+	opens graphql.kickstart.tools.proxy;
+	opens graphql.kickstart.tools.relay;
+	opens graphql.kickstart.tools.util;
+}


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
<!-- Resolves #<ISSUE_NUMBER> -->

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [ ] New or modified functionality is covered by tests

## Description
<!-- Briefly describe how you resolved the issue or a bug. -->
Now introducing java modules.
1. Updated java version to 9.
2. Separated out junit dependency from spock.
   - spock included both junit version 4.12 and 4.13
3. Updated maven-compiler-plugin to a more recent version that can handle modules.
4. Travis now builds with jdk 9

Current module-info file exports and opens all packages just to be safe, as this is how i tested it.
This can be reduced down to just the classes that are intended to be used by other projects.