### PR TITLE
Handle `extended input`

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
@@ -32,8 +32,9 @@ internal class SchemaClassScanner(
 
     private val initialDictionary = initialDictionary.mapValues { InitialDictionaryEntry(it.value) }
     private val extensionDefinitions = allDefinitions.filterIsInstance<ObjectTypeExtensionDefinition>()
+    private val inputExtensionDefinitions = allDefinitions.filterIsInstance<InputObjectTypeExtensionDefinition>()
 
-    private val definitionsByName = (allDefinitions.filterIsInstance<TypeDefinition<*>>() - extensionDefinitions).associateBy { it.name }
+    private val definitionsByName = (allDefinitions.filterIsInstance<TypeDefinition<*>>() - extensionDefinitions - inputExtensionDefinitions).associateBy { it.name }
     private val objectDefinitions = (allDefinitions.filterIsInstance<ObjectTypeDefinition>() - extensionDefinitions)
     private val objectDefinitionsByName = objectDefinitions.associateBy { it.name }
     private val interfaceDefinitionsByName = allDefinitions.filterIsInstance<InterfaceTypeDefinition>().associateBy { it.name }
@@ -173,7 +174,7 @@ internal class SchemaClassScanner(
         validateRootResolversWereUsed(rootTypeHolder.mutation, fieldResolvers)
         validateRootResolversWereUsed(rootTypeHolder.subscription, fieldResolvers)
 
-        return ScannedSchemaObjects(dictionary, observedDefinitions + extensionDefinitions, scalars, rootInfo, fieldResolversByType.toMap(), unusedDefinitions)
+        return ScannedSchemaObjects(dictionary, observedDefinitions + extensionDefinitions + inputExtensionDefinitions, scalars, rootInfo, fieldResolversByType.toMap(), unusedDefinitions)
     }
 
     private fun validateRootResolversWereUsed(rootType: RootType?, fieldResolvers: List<FieldResolver>) {

--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParser.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParser.kt
@@ -184,7 +184,7 @@ class SchemaParser internal constructor(
 
         builder.withDirectives(*buildDirectives(definition.directives, setOf(), Introspection.DirectiveLocation.INPUT_OBJECT))
 
-        extensionDefinitions.plus(definition).forEach {
+        (extensionDefinitions + definition).forEach {
             it.inputValueDefinitions.forEach { inputDefinition ->
                 val fieldBuilder = GraphQLInputObjectField.newInputObjectField()
                         .name(inputDefinition.name)

--- a/src/test/groovy/graphql/kickstart/tools/EndToEndSpec.groovy
+++ b/src/test/groovy/graphql/kickstart/tools/EndToEndSpec.groovy
@@ -509,6 +509,20 @@ class EndToEndSpec extends Specification {
         ]
     }
 
+    def "generated schema should handle extended input types"() {
+        when:
+        def data = Utils.assertNoGraphQlErrors(gql) {
+            '''
+                mutation {
+                    saveUser(input: {name: "John", password: "secret"})
+                }
+                '''
+        }
+
+        then:
+        data.saveUser == "John/secret"
+    }
+
     def "generated schema supports generic properties"() {
         when:
         def data = Utils.assertNoGraphQlErrors(gql) {

--- a/src/test/groovy/graphql/kickstart/tools/SchemaClassScannerSpec.groovy
+++ b/src/test/groovy/graphql/kickstart/tools/SchemaClassScannerSpec.groovy
@@ -177,11 +177,13 @@ class SchemaClassScannerSpec extends Specification {
                     extend input UserInput {
                         password: String
                     }
-                '''.stripIndent())
-                .resolvers(new GraphQLMutationResolver() {
-                    boolean save(Map map) { true }
-                }, new GraphQLQueryResolver() {
-                })
+                ''')
+                .resolvers(
+                        new GraphQLMutationResolver() {
+                            boolean save(Map map) { true }
+                        },
+                        new GraphQLQueryResolver() {}
+                )
                 .scan()
 
         then:

--- a/src/test/groovy/graphql/kickstart/tools/SchemaClassScannerSpec.groovy
+++ b/src/test/groovy/graphql/kickstart/tools/SchemaClassScannerSpec.groovy
@@ -2,6 +2,7 @@ package graphql.kickstart.tools
 
 import graphql.execution.batched.Batched
 import graphql.language.InputObjectTypeDefinition
+import graphql.language.InputObjectTypeExtensionDefinition
 import graphql.language.InterfaceTypeDefinition
 import graphql.language.ObjectTypeDefinition
 import graphql.language.ScalarTypeDefinition
@@ -157,6 +158,35 @@ class SchemaClassScannerSpec extends Specification {
         class ThirdInput {
             String id
         }
+    }
+
+    def "scanner handles input types extensions"() {
+        when:
+        ScannedSchemaObjects objects = SchemaParser.newParser()
+                .schemaString('''
+                    type Query { }
+
+                    type Mutation {
+                        save(input: UserInput!): Boolean
+                    }
+                    
+                    input UserInput {
+                        name: String                        
+                    }
+                    
+                    extend input UserInput {
+                        password: String
+                    }
+                '''.stripIndent())
+                .resolvers(new GraphQLMutationResolver() {
+                    boolean save(Map map) { true }
+                }, new GraphQLQueryResolver() {
+                })
+                .scan()
+
+        then:
+        objects.definitions.findAll { (it.class == InputObjectTypeExtensionDefinition.class) }.size() == 1
+        objects.definitions.findAll { (it.class == InputObjectTypeDefinition.class) }.size() == 1
     }
 
     def "scanner allows multiple return types for custom scalars"() {

--- a/src/test/kotlin/graphql/kickstart/tools/EndToEndSpecHelper.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/EndToEndSpecHelper.kt
@@ -111,12 +111,21 @@ input ComplexInputTypeTwo {
 type Mutation {
     addItem(newItem: NewItemInput!): Item!
     echoFiles(fileParts: [Upload!]!): [String!]!
+    saveUser(input: UserInput!): String
 }
 
 type Subscription {
     onItemCreated: Item!
     onItemCreatedCoroutineChannel: Item!
     onItemCreatedCoroutineChannelAndSuspendFunction: Item!
+}
+
+input UserInput {
+    name: String                        
+}
+
+extend input UserInput {
+    password: String
 }
 
 input ItemSearchInput {
@@ -320,6 +329,15 @@ abstract class ListListResolver<out E> {
 class Mutation : GraphQLMutationResolver {
     fun addItem(input: NewItemInput): Item {
         return Item(items.size, input.name, input.type, UUID.randomUUID(), listOf()) // Don't actually add the item to the list, since we want the test to be deterministic
+    }
+
+    fun saveUser(userInput: UserInput): String {
+        return userInput.name + "/" + userInput.password;
+    }
+
+    class UserInput {
+        var name: String = ""
+        var password: String = ""
     }
 }
 


### PR DESCRIPTION
Resolves #353

## Checklist
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description

The GraphQL spec allows `extend input`, but the graphql-java-tools library did not handle this case.

This commit, enables the following to work:

```
type Mutation {
    save(input: UserInput!): Boolean
}

input UserInput {
    name: String                        
}

extend input UserInput {
    password: String
}

# and later on:
# mutation {
#    saveUser(input: {name: "John", password: "secret"})
# }
```