### PR TITLE
388 fix optional argument handling

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/MethodFieldResolver.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/MethodFieldResolver.kt
@@ -92,11 +92,10 @@ internal class MethodFieldResolver(
                 }
 
                 if (value == null && isOptional) {
-                    if (environment.containsArgument(definition.name)) {
-                        return@add Optional.empty<Any>()
-                    } else {
+                    if (options.inputArgumentOptionalNullWhenOmitted && !environment.containsArgument(definition.name)) {
                         return@add null
                     }
+                    return@add Optional.empty<Any>()
                 }
 
                 if (value != null

--- a/src/main/kotlin/graphql/kickstart/tools/MethodFieldResolver.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/MethodFieldResolver.kt
@@ -92,7 +92,7 @@ internal class MethodFieldResolver(
                 }
 
                 if (value == null && isOptional) {
-                    if (options.inputArgumentOptionalNullWhenOmitted && !environment.containsArgument(definition.name)) {
+                    if (options.inputArgumentOptionalDetectOmission && !environment.containsArgument(definition.name)) {
                         return@add null
                     }
                     return@add Optional.empty<Any>()

--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
@@ -25,7 +25,7 @@ data class SchemaParserOptions internal constructor(
     val allowUnimplementedResolvers: Boolean,
     val objectMapperProvider: PerFieldObjectMapperProvider,
     val proxyHandlers: List<ProxyHandler>,
-    val inputArgumentOptionalNullWhenOmitted: Boolean,
+    val inputArgumentOptionalDetectOmission: Boolean,
     val preferGraphQLResolver: Boolean,
     val introspectionEnabled: Boolean,
     val coroutineContextProvider: CoroutineContextProvider,
@@ -51,7 +51,7 @@ data class SchemaParserOptions internal constructor(
         private var allowUnimplementedResolvers = false
         private var objectMapperProvider: PerFieldObjectMapperProvider = PerFieldConfiguringObjectMapperProvider()
         private val proxyHandlers: MutableList<ProxyHandler> = mutableListOf(Spring4AopProxyHandler(), GuiceAopProxyHandler(), JavassistProxyHandler(), WeldProxyHandler())
-        private var inputArgumentOptionalNullWhenOmitted = false
+        private var inputArgumentOptionalDetectOmission = false
         private var preferGraphQLResolver = false
         private var introspectionEnabled = true
         private var coroutineContextProvider: CoroutineContextProvider? = null
@@ -82,8 +82,8 @@ data class SchemaParserOptions internal constructor(
             this.allowUnimplementedResolvers = allowUnimplementedResolvers
         }
 
-        fun inputArgumentOptionalNullWhenOmitted(inputArgumentOptionalNullWhenOmitted: Boolean) = this.apply {
-            this.inputArgumentOptionalNullWhenOmitted = inputArgumentOptionalNullWhenOmitted
+        fun inputArgumentOptionalDetectOmission(inputArgumentOptionalDetectOmission: Boolean) = this.apply {
+            this.inputArgumentOptionalDetectOmission = inputArgumentOptionalDetectOmission
         }
 
         fun preferGraphQLResolver(preferGraphQLResolver: Boolean) = this.apply {
@@ -158,7 +158,7 @@ data class SchemaParserOptions internal constructor(
                 allowUnimplementedResolvers,
                 objectMapperProvider,
                 proxyHandlers,
-                inputArgumentOptionalNullWhenOmitted,
+                inputArgumentOptionalDetectOmission,
                 preferGraphQLResolver,
                 introspectionEnabled,
                 coroutineContextProvider,

--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
@@ -25,6 +25,7 @@ data class SchemaParserOptions internal constructor(
     val allowUnimplementedResolvers: Boolean,
     val objectMapperProvider: PerFieldObjectMapperProvider,
     val proxyHandlers: List<ProxyHandler>,
+    val inputArgumentOptionalNullWhenOmitted: Boolean,
     val preferGraphQLResolver: Boolean,
     val introspectionEnabled: Boolean,
     val coroutineContextProvider: CoroutineContextProvider,
@@ -50,6 +51,7 @@ data class SchemaParserOptions internal constructor(
         private var allowUnimplementedResolvers = false
         private var objectMapperProvider: PerFieldObjectMapperProvider = PerFieldConfiguringObjectMapperProvider()
         private val proxyHandlers: MutableList<ProxyHandler> = mutableListOf(Spring4AopProxyHandler(), GuiceAopProxyHandler(), JavassistProxyHandler(), WeldProxyHandler())
+        private var inputArgumentOptionalNullWhenOmitted = false
         private var preferGraphQLResolver = false
         private var introspectionEnabled = true
         private var coroutineContextProvider: CoroutineContextProvider? = null
@@ -78,6 +80,10 @@ data class SchemaParserOptions internal constructor(
 
         fun allowUnimplementedResolvers(allowUnimplementedResolvers: Boolean) = this.apply {
             this.allowUnimplementedResolvers = allowUnimplementedResolvers
+        }
+
+        fun inputArgumentOptionalNullWhenOmitted(inputArgumentOptionalNullWhenOmitted: Boolean) = this.apply {
+            this.inputArgumentOptionalNullWhenOmitted = inputArgumentOptionalNullWhenOmitted
         }
 
         fun preferGraphQLResolver(preferGraphQLResolver: Boolean) = this.apply {
@@ -146,9 +152,18 @@ data class SchemaParserOptions internal constructor(
                 genericWrappers
             }
 
-            return SchemaParserOptions(contextClass, wrappers, allowUnimplementedResolvers, objectMapperProvider,
-                proxyHandlers, preferGraphQLResolver, introspectionEnabled, coroutineContextProvider,
-                typeDefinitionFactories, fieldVisibility
+            return SchemaParserOptions(
+                contextClass,
+                wrappers,
+                allowUnimplementedResolvers,
+                objectMapperProvider,
+                proxyHandlers,
+                inputArgumentOptionalNullWhenOmitted,
+                preferGraphQLResolver,
+                introspectionEnabled,
+                coroutineContextProvider,
+                typeDefinitionFactories,
+                fieldVisibility
             )
         }
     }

--- a/src/test/kotlin/graphql/kickstart/tools/MethodFieldResolverTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/MethodFieldResolverTest.kt
@@ -75,7 +75,7 @@ class MethodFieldResolverTest {
                 fun testNull(input: Optional<String>) = input.toString()
             })
             .options(SchemaParserOptions.newOptions()
-                .inputArgumentOptionalNullWhenOmitted(true)
+                .inputArgumentOptionalDetectOmission(true)
                 .build())
             .build()
             .makeExecutableSchema()

--- a/src/test/kotlin/graphql/kickstart/tools/MethodFieldResolverTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/MethodFieldResolverTest.kt
@@ -10,11 +10,101 @@ import org.junit.Test
 import java.lang.reflect.InvocationHandler
 import java.lang.reflect.Method
 import java.lang.reflect.Proxy
+import java.util.*
 
 class MethodFieldResolverTest {
 
     @Test
-    fun shouldHandleScalarTypesAsMethodInputArgument() {
+    fun `should handle Optional type as method input argument`() {
+        val schema = SchemaParser.newParser()
+            .schemaString("""
+                    type Query {
+                        testValue(input: String): String
+                        testOmitted(input: String): String
+                        testNull(input: String): String
+                    }
+                    """
+            )
+            .scalars(customScalarType)
+            .resolvers(object : GraphQLQueryResolver {
+                fun testValue(input: Optional<String>) = input.toString()
+                fun testOmitted(input: Optional<String>) = input.toString()
+                fun testNull(input: Optional<String>) = input.toString()
+            })
+            .build()
+            .makeExecutableSchema()
+
+        val gql = GraphQL.newGraphQL(schema).build()
+
+        val result = gql
+            .execute(ExecutionInput.newExecutionInput()
+                .query("""
+                            query {
+                                testValue(input: "test-value")
+                                testOmitted
+                                testNull(input: null)
+                            }
+                            """)
+                .context(Object())
+                .root(Object()))
+
+        val expected = mapOf(
+            "testValue" to "Optional[test-value]",
+            "testOmitted" to "Optional.empty",
+            "testNull" to "Optional.empty"
+        )
+
+        Assert.assertEquals(expected, result.getData())
+    }
+
+    @Test
+    fun `should handle Optional type as method input argument with omission detection`() {
+        val schema = SchemaParser.newParser()
+            .schemaString("""
+                    type Query {
+                        testValue(input: String): String
+                        testOmitted(input: String): String
+                        testNull(input: String): String
+                    }
+                    """
+            )
+            .scalars(customScalarType)
+            .resolvers(object : GraphQLQueryResolver {
+                fun testValue(input: Optional<String>) = input.toString()
+                fun testOmitted(input: Optional<String>?) = input.toString()
+                fun testNull(input: Optional<String>) = input.toString()
+            })
+            .options(SchemaParserOptions.newOptions()
+                .inputArgumentOptionalNullWhenOmitted(true)
+                .build())
+            .build()
+            .makeExecutableSchema()
+
+        val gql = GraphQL.newGraphQL(schema).build()
+
+        val result = gql
+            .execute(ExecutionInput.newExecutionInput()
+                .query("""
+                            query {
+                                testValue(input: "test-value")
+                                testOmitted
+                                testNull(input: null)
+                            }
+                            """)
+                .context(Object())
+                .root(Object()))
+
+        val expected = mapOf(
+            "testValue" to "Optional[test-value]",
+            "testOmitted" to "null",
+            "testNull" to "Optional.empty"
+        )
+
+        Assert.assertEquals(expected, result.getData())
+    }
+
+    @Test
+    fun `should handle scalar types as method input argument`() {
         val schema = SchemaParser.newParser()
             .schemaString("""
                     scalar CustomScalar
@@ -47,7 +137,7 @@ class MethodFieldResolverTest {
     }
 
     @Test
-    fun shouldHandleListsOfScalarTypes() {
+    fun `should handle lists of scalar types`() {
         val schema = SchemaParser.newParser()
             .schemaString("""
                     scalar CustomScalar
@@ -80,7 +170,7 @@ class MethodFieldResolverTest {
     }
 
     @Test
-    fun shouldHandleProxies() {
+    fun `should handle proxies`() {
         val invocationHandler = object : InvocationHandler {
             override fun invoke(proxy: Any, method: Method, args: Array<out Any>): Any {
                 return when (method.name) {


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
Resolves #388

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description
<!-- Briefly describe how you resolved the issue or a bug. -->
Changes the default behavior of `Optional` mapping when used as an input parameter.
This is an adjustment to my previous PR on this topic https://github.com/graphql-java-kickstart/graphql-java-tools/pull/310.

Both options are now supported and the behavior is configurable via the boolean switch `inputArgumentOptionalDetectOmission`:
- when `true` an omitted GraphQL argument during query is converted to `null` and an explicit GraphQL `null` is converted to `Optional.empty()` (https://github.com/graphql-java-kickstart/graphql-java-tools/pull/310)
- when `false` both an omitted GraphQL argument and explicit `null` is converted to `Optional.empty()`; therefore the value is never `null`; **this is the new default!**

I am choosing to make this a breaking change and make the second option the default for these reasons:
1. Omission detection never worked in input objects which was confusing. 
2. Omitting arguments is not well supported by various client libraries such as Apollo. It is hard to store reusable query templates when omitting arguments.
3. The expectation is that an `Optional` is never `null`. 

The old behavior will be kept for those users that do not care about the reasons above and want to continue using it. But they will have to opt-in to it by setting `inputArgumentOptionalDetectOmission` to `true`.

