### PR TITLE
Upgrade kotlin and kotlin-coroutines to versions 1.3.72 and 1.3.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>1.8</java.version>
-        <kotlin.version>1.3.70</kotlin.version>
-        <kotlin-coroutines.version>1.2.1</kotlin-coroutines.version>
+        <kotlin.version>1.3.72</kotlin.version>
+        <kotlin-coroutines.version>1.3.9</kotlin-coroutines.version>
         <jackson.version>2.10.3</jackson.version>
         <graphql-java.version>15.0</graphql-java.version>
 

--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
@@ -5,7 +5,6 @@ import graphql.kickstart.tools.proxy.*
 import graphql.kickstart.tools.relay.RelayConnectionFactory
 import graphql.kickstart.tools.util.JavaType
 import graphql.kickstart.tools.util.ParameterizedTypeImpl
-import graphql.kickstart.tools.util.coroutineScope
 import graphql.schema.DataFetchingEnvironment
 import graphql.schema.visibility.GraphqlFieldVisibility
 import kotlinx.coroutines.Dispatchers
@@ -136,8 +135,8 @@ data class SchemaParserOptions internal constructor(
                     GenericWrapper(CompletableFuture::class, 0),
                     GenericWrapper(CompletionStage::class, 0),
                     GenericWrapper(Publisher::class, 0),
-                    GenericWrapper.withTransformer(ReceiveChannel::class, 0, { receiveChannel, environment ->
-                        environment.coroutineScope().publish(coroutineContextProvider.provide()) {
+                    GenericWrapper.withTransformer(ReceiveChannel::class, 0, { receiveChannel, _ ->
+                        publish(coroutineContextProvider.provide()) {
                             try {
                                 for (item in receiveChannel) {
                                     send(item)

--- a/src/test/groovy/graphql/kickstart/tools/SchemaParserSpec.groovy
+++ b/src/test/groovy/graphql/kickstart/tools/SchemaParserSpec.groovy
@@ -266,10 +266,10 @@ class SchemaParserSpec extends Specification {
         when:
         GraphQLSchema schema = SchemaParser.newParser()
                 .schemaString('''\
-                                type Query {
-                                    id: ID!
-                                }
-                            '''.stripIndent())
+                type Query {
+                    id: ID!
+                }
+                '''.stripIndent())
                 .resolvers(new QueryWithIdResolver())
                 .build()
                 .makeExecutableSchema()

--- a/src/test/groovy/graphql/kickstart/tools/SchemaParserSpec.groovy
+++ b/src/test/groovy/graphql/kickstart/tools/SchemaParserSpec.groovy
@@ -266,10 +266,10 @@ class SchemaParserSpec extends Specification {
         when:
         GraphQLSchema schema = SchemaParser.newParser()
                 .schemaString('''\
-                type Query {
-                    id: ID!
-                }
-                '''.stripIndent())
+                    |type Query {
+                    |    id: ID!
+                    |}
+                '''.stripMargin())
                 .resolvers(new QueryWithIdResolver())
                 .build()
                 .makeExecutableSchema()


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
Fixes #378
<!-- Resolves #<ISSUE_NUMBER> -->

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description
Replaced deprecated CoroutineScope.publish(...) with top-level publish(...) method in SchemaParserOptions(See: https://github.com/Kotlin/kotlinx.coroutines/blob/master/reactive/kotlinx-coroutines-reactive/src/Publish.kt). No new tests were added but existing ones looked sufficient to me. I noticed that @oliemansm didn't upgrade the kotlin-coroutines lib in the "upgrade-dependencies" branch (See: commit 4543ccd) so there might be a reason to not do this update that I am not aware of?!
