### PR TITLE
fix: Force add 'orphan' types used by apollo federation to schema

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
@@ -70,6 +70,10 @@ internal class SchemaClassScanner(
         handleRootType(rootTypeHolder.query)
         handleRootType(rootTypeHolder.mutation)
         handleRootType(rootTypeHolder.subscription)
+        val federatedExtensionDefinitions = objectDefinitions
+                .filter { definition -> definition.directivesByName.containsKey("extends") }
+
+        handleInterfaceOrUnionSubTypes(federatedExtensionDefinitions) { "Object type '${it.name}' is an extensionType. Please pass a class for type '${it.name}' in the parser's dictionary." }
 
         scanQueue()
 


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
Resolves #442

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [ ] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [ ] New or modified functionality is covered by tests

## Description

As described in #442, the main issue is that, for some Apollo Federation contexts, it is possible to have "orphan" types that are not referenced by any other types in the schema/graph.

This is a very naive attempt to fix it by making sure we add types with the `@extends` directive, but asking clients to specify the type of it in the `SchemaParserDictionary`.

It's marked as a draft because it is mostly to highlight the issue, but I'm looking to get for some pointers in order to a proper fix for it.

Possible things to consider on the real fix:
* [ ] Tests
* [ ] Refactor `handleInterfaceOrUnionSubTypes` to be more generic (maybe just rename it? or reuse the generic parts?)
* [ ] Discover the `javaType` for the extend entity types automatically as it is done for the other types.