### PR TITLE
Prevent to add PageInfo definition if not needed

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/relay/RelayConnectionFactory.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/relay/RelayConnectionFactory.kt
@@ -6,12 +6,17 @@ import graphql.language.*
 class RelayConnectionFactory : TypeDefinitionFactory {
 
     override fun create(existing: MutableList<Definition<*>>): List<Definition<*>> {
+        val connectionDirectives = findConnectionDirectives(existing)
+        if (connectionDirectives.isEmpty()) {
+            return emptyList()
+        }
+
         val definitions = mutableListOf<Definition<*>>()
         val definitionsByName = existing.filterIsInstance<TypeDefinition<*>>()
             .associateBy { it.name }
             .toMutableMap()
 
-        findConnectionDirectives(existing)
+        connectionDirectives
             .flatMap { createDefinitions(it) }
             .forEach {
                 if (!definitionsByName.containsKey(it.name)) {

--- a/src/main/kotlin/graphql/kickstart/tools/relay/RelayConnectionFactory.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/relay/RelayConnectionFactory.kt
@@ -8,6 +8,7 @@ class RelayConnectionFactory : TypeDefinitionFactory {
     override fun create(existing: MutableList<Definition<*>>): List<Definition<*>> {
         val connectionDirectives = findConnectionDirectives(existing)
         if (connectionDirectives.isEmpty()) {
+            // do not add Relay definitions unless needed
             return emptyList()
         }
 

--- a/src/test/kotlin/graphql/kickstart/tools/relay/RelayConnectionFactoryTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/relay/RelayConnectionFactoryTest.kt
@@ -1,0 +1,20 @@
+package graphql.kickstart.tools.relay
+
+import graphql.language.Definition
+import org.junit.Assert
+import org.junit.Test
+
+class RelayConnectionFactoryTest {
+
+    @Test
+    fun `should not add new definition when no @connection directive`() {
+        // setup
+        val factory = RelayConnectionFactory()
+        val existing = mutableListOf<Definition<*>>()
+
+        val newDefinitions = factory.create(existing)
+
+        // expect
+        Assert.assertEquals(newDefinitions.size, 0)
+    }
+}

--- a/src/test/kotlin/graphql/kickstart/tools/relay/RelayConnectionFactoryTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/relay/RelayConnectionFactoryTest.kt
@@ -1,7 +1,7 @@
 package graphql.kickstart.tools.relay
 
 import graphql.language.Definition
-import org.junit.Assert
+import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class RelayConnectionFactoryTest {
@@ -15,6 +15,6 @@ class RelayConnectionFactoryTest {
         val newDefinitions = factory.create(existing)
 
         // expect
-        Assert.assertEquals(newDefinitions.size, 0)
+        assertEquals(newDefinitions.size, 0)
     }
 }


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
<!-- Resolves #<ISSUE_NUMBER> -->

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description
<!-- Briefly describe how you resolved the issue or a bug. -->
Prevent `RelayConnectionFactory` to do extra work and add new definition when not needed.