### PR TITLE
Allowing nested inputs defined in extensions to be parsed as well

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
@@ -333,7 +333,7 @@ internal class SchemaClassScanner(
             }
 
             is InputObjectTypeDefinition -> {
-                graphQLType.inputValueDefinitions.forEach { inputValueDefinition ->
+                (listOf(graphQLType) + inputExtensionDefinitions.filter { it.name == graphQLType.name }).flatMap { it.inputValueDefinitions }.forEach { inputValueDefinition ->
                     val inputGraphQLType = inputValueDefinition.type.unwrap()
                     if (inputGraphQLType is TypeName && !ScalarInfo.GRAPHQL_SPECIFICATION_SCALARS_DEFINITIONS.containsKey(inputGraphQLType.name)) {
                         val inputValueJavaType = findInputValueType(inputValueDefinition.name, inputGraphQLType, javaType.unwrap())


### PR DESCRIPTION
## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description

Fields declared in extension would not be parsed, this PR fixes that issue with corresponding UT.