### PR TITLE
Remove bintray and deploy to maven central

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,19 +20,20 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Bintray
+      - name: Setup Maven Central
         uses: actions/setup-java@v2
         with:
           java-version: '8'
           distribution: 'adopt'
-          server-id: bintray
-          server-username: BINTRAY_USER
-          server-password: BINTRAY_PASS
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
+          gpg-private-key: ${{ secrets.GPG_KEY_CONTENTS }}
+          gpg-passphrase: GPG_PASSPHRASE
       - name: Publish release
         run: bash github-build.sh
         env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_PASS: ${{ secrets.BINTRAY_PASSWORD }}
           MAVEN_USERNAME: ${{ secrets.OSS_USER_TOKEN_KEY }}
           MAVEN_PASSWORD: ${{ secrets.OSS_USER_TOKEN_PASS }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_SIGNING_PASSWORD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -23,18 +23,16 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Setup Bintray
+      - name: Setup Maven Central
         uses: actions/setup-java@v2
         with:
           java-version: '8'
           distribution: 'adopt'
-          server-id: bintray
-          server-username: BINTRAY_USER
-          server-password: BINTRAY_PASS
+          server-id: ossrh
+          server-username: MAVEN_USERNAME
+          server-password: MAVEN_PASSWORD
       - name: Publish release
-        run: mvn --batch-mode -Pbintray deploy
+        run: mvn --batch-mode deploy
         env:
-          BINTRAY_USER: ${{ secrets.BINTRAY_USER }}
-          BINTRAY_PASS: ${{ secrets.BINTRAY_PASSWORD }}
           MAVEN_USERNAME: ${{ secrets.OSS_USER_TOKEN_KEY }}
           MAVEN_PASSWORD: ${{ secrets.OSS_USER_TOKEN_PASS }}

--- a/github-build.sh
+++ b/github-build.sh
@@ -43,10 +43,10 @@ commitNextVersion() {
 git config --global user.email "actions@github.com"
 git config --global user.name "GitHub Actions"
 
-echo "Deploying release to Bintray"
+echo "Deploying release to Maven Central"
 removeSnapshots
 
-mvn --batch-mode -Pbintray deploy
+mvn --batch-mode -Prelease deploy
 
 commitRelease
 bumpVersion

--- a/pom.xml
+++ b/pom.xml
@@ -245,15 +245,6 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-release-plugin</artifactId>
-                <version>2.5.3</version>
-                <configuration>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
-                    <generateReleasePoms>false</generateReleasePoms>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
                 <executions>
@@ -279,18 +270,29 @@
                         </goals>
                         <configuration>
                             <rules>
-                                <dependencyConvergence />
+                                <dependencyConvergence/>
                             </rules>
                         </configuration>
                     </execution>
                 </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.sonatype.plugins</groupId>
+                <artifactId>nexus-staging-maven-plugin</artifactId>
+                <version>1.6.8</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <serverId>ossrh</serverId>
+                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                </configuration>
             </plugin>
         </plugins>
     </build>
 
     <profiles>
         <profile>
-            <id>bintray</id>
+            <id>release</id>
             <build>
                 <plugins>
                     <plugin>
@@ -302,7 +304,7 @@
                                 <id>attach-sources</id>
                                 <phase>package</phase>
                                 <goals>
-                                    <goal>jar</goal>
+                                    <goal>jar-no-fork</goal>
                                 </goals>
                             </execution>
                         </executions>
@@ -319,6 +321,27 @@
                                 </goals>
                             </execution>
                         </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <version>1.6</version>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <!-- Prevent gpg from using pinentry programs -->
+                            <gpgArguments>
+                                <arg>--pinentry-mode</arg>
+                                <arg>loopback</arg>
+                            </gpgArguments>
+                        </configuration>
                     </plugin>
                 </plugins>
             </build>
@@ -341,19 +364,9 @@
     </licenses>
     <distributionManagement>
         <snapshotRepository>
-            <id>bintray</id>
-            <name>graphql-java-kickstart-graphql-java-tools</name>
-            <url>http://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
-
-        <!-- Released with: mvn release:clean release:prepare release:perform -B -e -Pbintray -->
-        <repository>
-            <id>bintray</id>
-            <name>graphql-java-kickstart-graphql-java-tools</name>
-            <url>
-                https://api.bintray.com/maven/graphql-java-kickstart/releases/graphql-java-tools/;publish=1
-            </url>
-        </repository>
     </distributionManagement>
     <scm>
         <connection>scm:git:https://github.com/graphql-java-kickstart/graphql-java-tools.git
@@ -361,6 +374,5 @@
         <developerConnection>scm:git:https://github.com/graphql-java-kickstart/graphql-java-tools.git
         </developerConnection>
         <url>https://github.com/graphql-java-kickstart/graphql-java-tools</url>
-        <tag>HEAD</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -284,7 +284,8 @@
                 <configuration>
                     <serverId>ossrh</serverId>
                     <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                    <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                    <!-- temporarily set to false to test release deployment-->
+                    <autoReleaseAfterClose>false</autoReleaseAfterClose>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -283,7 +283,7 @@
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
-                    <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+                    <nexusUrl>https://oss.sonatype.org/</nexusUrl>
                     <autoReleaseAfterClose>true</autoReleaseAfterClose>
                 </configuration>
             </plugin>
@@ -365,7 +365,7 @@
     <distributionManagement>
         <snapshotRepository>
             <id>ossrh</id>
-            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
         </snapshotRepository>
     </distributionManagement>
     <scm>


### PR DESCRIPTION

## Checklist
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description
Following the closure of bintray we need to replace it with direct deployment to maven central. 
Unfortunately, following the rest of the org's gradle based config doesn't seem possible. 
However, according to [this guide](https://central.sonatype.org/publish/publish-maven) and [the documentation here](https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#Publishing-using-Apache-Maven) this should work. 
