### PR TITLE
Switching to use shareable renovate presets

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,14 +1,5 @@
 {
   "extends": [
-    "config:base"
-  ],
-  "packageRules": [
-    {
-      "description": "Ignore graphql-java snapshot builds",
-      "matchPackagePatterns": [
-        "^com.graphql-java"
-      ],
-      "allowedVersions": "/^[0-9]+\\.[0-9]+\\.[0-9]+?$/"
-    }
+    "github>graphql-java-kickstart/renovate-config"
   ]
 }


### PR DESCRIPTION
Adopt a [centralized repository](https://github.com/graphql-java-kickstart/renovate-config) to share common renovate configurations across all kickstart projects

Other projects already migrated