### PR TITLE
Scan for resolvers that have a supertype of the data class

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/ResolverInfo.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/ResolverInfo.kt
@@ -48,21 +48,10 @@ internal class NormalResolverInfo(
     }
 }
 
-internal class MultiResolverInfo(val resolverInfoList: List<NormalResolverInfo>) : DataClassTypeResolverInfo, ResolverInfo() {
-    override val dataClassType = findDataClass()
 
-    /**
-     * Checks if all `ResolverInfo` instances are related to the same data type
-     */
-    private fun findDataClass(): Class<out Any> {
-        val dataClass = resolverInfoList.asSequence().map { it.dataClassType }.distinct().singleOrNull()
-
-        if (dataClass == null) {
-            throw ResolverError("Resolvers may not use the same type.")
-        } else {
-            return dataClass
-        }
-    }
+internal class MultiResolverInfo(val resolverInfoList: List<NormalResolverInfo>,
+                                 override val dataClassType: Class<out Any>
+) : DataClassTypeResolverInfo, ResolverInfo() {
 
     override fun getFieldSearches(): List<FieldResolverScanner.Search> {
         return resolverInfoList

--- a/src/main/kotlin/graphql/kickstart/tools/resolver/FieldResolverScanner.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/resolver/FieldResolverScanner.kt
@@ -127,7 +127,8 @@ internal class FieldResolverScanner(val options: SchemaParserOptions) {
     private fun verifyMethodArguments(method: Method, requiredCount: Int, search: Search): Boolean {
         val appropriateFirstParameter = if (search.requiredFirstParameterType != null) {
             method.genericParameterTypes.firstOrNull()?.let {
-                it == search.requiredFirstParameterType || method.declaringClass.typeParameters.contains(it)
+                it == search.requiredFirstParameterType || (it is Class<*> && it.unwrap().isAssignableFrom(search.requiredFirstParameterType))
+                        || method.declaringClass.typeParameters.contains(it)
             } ?: false
         } else {
             true

--- a/src/test/kotlin/graphql/kickstart/tools/EndToEndSpecHelper.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/EndToEndSpecHelper.kt
@@ -16,7 +16,7 @@ import javax.servlet.http.Part
 
 fun createSchema() = SchemaParser.newParser()
     .schemaString(schemaDefinition)
-    .resolvers(Query(), Mutation(), Subscription(), ItemResolver(), UnusedRootResolver(), UnusedResolver(), EchoFilesResolver())
+    .resolvers(Query(), Mutation(), Subscription(), ItemResolver(), ItemInterfaceResolver(), UnusedRootResolver(), UnusedResolver(), EchoFilesResolver())
     .scalars(customScalarUUID, customScalarMap, customScalarId, uploadScalar)
     .dictionary("OtherItem", OtherItemWithWrongName::class)
     .dictionary("ThirdItem", ThirdItem::class)
@@ -155,6 +155,7 @@ type Item implements ItemInterface {
     type: Type!
     uuid: UUID!
     tags(names: [String!]): [Tag!]
+    uppercaseName: String!
 }
 
 type OtherItem implements ItemInterface {
@@ -392,6 +393,10 @@ class ItemResolver : GraphQLResolver<Item> {
     fun tags(item: Item, names: List<String>?): List<Tag> = item.tags.filter {
         names?.contains(it.name) ?: true
     }
+}
+
+class ItemInterfaceResolver : GraphQLResolver<ItemInterface> {
+    fun uppercaseName(item: ItemInterface): String = item.name.toUpperCase()
 }
 
 class EchoFilesResolver : GraphQLMutationResolver {


### PR DESCRIPTION
Fixes #497

## Checklist
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description
Made necessary changes to class scanning logic to support using supertypes in resolvers.
