### PR TITLE
make directives repeatable by default

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParser.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParser.kt
@@ -297,14 +297,11 @@ class SchemaParser internal constructor(
     }
 
     private fun buildDirectives(directives: List<Directive>, directiveLocation: Introspection.DirectiveLocation): Array<GraphQLDirective> {
-        val names = mutableSetOf<String>()
-
         val output = mutableListOf<GraphQLDirective>()
         for (directive in directives) {
-            if (!names.contains(directive.name)) {
-                names.add(directive.name)
                 val graphQLDirective = GraphQLDirective.newDirective()
                     .name(directive.name)
+                    .repeatable(true)
                     .description(getDocumentation(directive, options))
                     .comparatorRegistry(runtimeWiring.comparatorRegistry)
                     .validLocation(directiveLocation)
@@ -320,7 +317,6 @@ class SchemaParser internal constructor(
                     .build()
 
                 output.add(graphQLDirective)
-            }
         }
 
         return output.toTypedArray()


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
 Fixes #615 
<!-- Resolves #<ISSUE_NUMBER> -->

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description
<!-- Briefly describe how you resolved the issue or a bug. -->
Currently directive definitions are being ignored when parsing the schema and all directives are being assumed non-repeated. This is causing issues, for example, when using apollo-federation, as it prevents duplicate @key annotations on the federated entity.
While this PR doesn't fix the problem in it's entirety (for example, by parsing directives properly and validating them, as mentioned in #225 ) - it at least allows directive information not to get lost, by assuming all directives could be repeated. 