### PR TITLE
Add support for unused types for all dictionary types

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaClassScanner.kt
@@ -91,15 +91,13 @@ internal class SchemaClassScanner(
             do {
                 val unusedDefinitions = (definitionsByName.values - (dictionary.keys.toSet() + unvalidatedTypes))
                     .filter { definition -> definition.name != "PageInfo" }
-                    .filterIsInstance<ObjectTypeDefinition>().distinct()
+                    .distinct()
 
                 if (unusedDefinitions.isEmpty()) {
                     break
                 }
 
-                val unusedDefinition = unusedDefinitions.first()
-
-                handleDictionaryTypes(listOf(unusedDefinition)) { "Object type '${it.name}' is unused and includeUnusedTypes is true. Please pass a class for type '${it.name}' in the parser's dictionary." }
+                handleDictionaryTypes(unusedDefinitions) { "Type '${it.name}' is unused and includeUnusedTypes is true. Please pass a class for type '${it.name}' in the parser's dictionary." }
             } while (scanQueue())
         }
 
@@ -229,7 +227,7 @@ internal class SchemaClassScanner(
         }.flatten().distinct()
     }
 
-    private fun handleDictionaryTypes(types: List<ObjectTypeDefinition>, failureMessage: (ObjectTypeDefinition) -> String) {
+    private fun handleDictionaryTypes(types: List<TypeDefinition<*>>, failureMessage: (TypeDefinition<*>) -> String) {
         types.forEach { type ->
             val dictionaryContainsType = dictionary.filter { it.key.name == type.name }.isNotEmpty()
             if (!unvalidatedTypes.contains(type) && !dictionaryContainsType) {

--- a/src/test/kotlin/graphql/kickstart/tools/SchemaClassScannerTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/SchemaClassScannerTest.kt
@@ -497,12 +497,19 @@ class SchemaClassScannerTest {
                 type Implementation implements SomeInterface {
                     value: String
                 }
+                
+                union SomeUnion = Unused | Implementation
+                
+                enum SomeEnum {
+                   A
+                   B
+                }
                 """)
             .resolvers(object : GraphQLQueryResolver {
                 fun whatever(): Whatever? = null
             })
             .options(SchemaParserOptions.newOptions().includeUnusedTypes(true).build())
-            .dictionary(Unused::class, Implementation::class)
+            .dictionary(Unused::class, Implementation::class, SomeInterface::class, SomeUnion::class, SomeEnum::class)
             .build()
             .makeExecutableSchema()
 

--- a/src/test/kotlin/graphql/kickstart/tools/TestInterfaces.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/TestInterfaces.kt
@@ -14,3 +14,10 @@ interface SomeInterface {
     fun getValue(): String?
 }
 
+interface SomeUnion
+
+enum class SomeEnum {
+    A,
+    B
+}
+


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
Resolves #736 

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [X] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [X] New or modified functionality is covered by tests

## Description

For unused type handling in SchemaClassScanner, when processing unused types, allow the dictionary to inject all types (EnumTypeDefinition, InterfaceTypeDefinition, etc) in addition to ObjectTypeDefinition.
