### PR TITLE
Provider for creating missing resolver data fetcher to provide options and field definition to factory

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
@@ -92,7 +92,7 @@ data class SchemaParserOptions internal constructor(
             this.allowUnimplementedResolvers = allowUnimplementedResolvers
         }
 
-        @Deprecated("Use missingResolverDataFetcherProvider instead.", level = DeprecationLevel.WARNING)
+        @Deprecated("Use missingResolverDataFetcherProvider instead.")
         fun missingResolverDataFetcher(missingResolverDataFetcher: DataFetcher<Any?>?) = this.apply {
             this.missingResolverDataFetcher = missingResolverDataFetcher
         }

--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
@@ -24,7 +24,7 @@ data class SchemaParserOptions internal constructor(
     val contextClass: Class<*>?,
     val genericWrappers: List<GenericWrapper>,
     val allowUnimplementedResolvers: Boolean,
-    @Deprecated("Use missingResolverDataFetcherProvider instead.", level = DeprecationLevel.WARNING)
+    @Deprecated("Use missingResolverDataFetcherProvider instead.")
     val missingResolverDataFetcher: DataFetcher<Any?>?,
     val missingResolverDataFetcherProvider: MissingResolverDataFetcherProvider?,
     val objectMapperProvider: PerFieldObjectMapperProvider,

--- a/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/SchemaParserOptions.kt
@@ -3,6 +3,7 @@ package graphql.kickstart.tools
 import com.fasterxml.jackson.databind.ObjectMapper
 import graphql.kickstart.tools.proxy.*
 import graphql.kickstart.tools.relay.RelayConnectionFactory
+import graphql.kickstart.tools.resolver.MissingResolverDataFetcherProvider
 import graphql.kickstart.tools.util.JavaType
 import graphql.kickstart.tools.util.ParameterizedTypeImpl
 import graphql.schema.DataFetcher
@@ -23,7 +24,9 @@ data class SchemaParserOptions internal constructor(
     val contextClass: Class<*>?,
     val genericWrappers: List<GenericWrapper>,
     val allowUnimplementedResolvers: Boolean,
+    @Deprecated("Use missingResolverDataFetcherProvider instead.", level = DeprecationLevel.WARNING)
     val missingResolverDataFetcher: DataFetcher<Any?>?,
+    val missingResolverDataFetcherProvider: MissingResolverDataFetcherProvider?,
     val objectMapperProvider: PerFieldObjectMapperProvider,
     val proxyHandlers: List<ProxyHandler>,
     val inputArgumentOptionalDetectOmission: Boolean,
@@ -53,6 +56,7 @@ data class SchemaParserOptions internal constructor(
         private var useDefaultGenericWrappers = true
         private var allowUnimplementedResolvers = false
         private var missingResolverDataFetcher: DataFetcher<Any?>? = null
+        private var missingResolverDataFetcherProvider: MissingResolverDataFetcherProvider? = null
         private var objectMapperProvider: PerFieldObjectMapperProvider = PerFieldConfiguringObjectMapperProvider()
         private val proxyHandlers: MutableList<ProxyHandler> = mutableListOf(Spring4AopProxyHandler(), GuiceAopProxyHandler(), JavassistProxyHandler(), WeldProxyHandler())
         private var inputArgumentOptionalDetectOmission = false
@@ -88,8 +92,13 @@ data class SchemaParserOptions internal constructor(
             this.allowUnimplementedResolvers = allowUnimplementedResolvers
         }
 
+        @Deprecated("Use missingResolverDataFetcherProvider instead.", level = DeprecationLevel.WARNING)
         fun missingResolverDataFetcher(missingResolverDataFetcher: DataFetcher<Any?>?) = this.apply {
             this.missingResolverDataFetcher = missingResolverDataFetcher
+        }
+
+        fun missingResolverDataFetcherProvider(missingResolverDataFetcherProvider: MissingResolverDataFetcherProvider?) = this.apply {
+            this.missingResolverDataFetcherProvider = missingResolverDataFetcherProvider
         }
 
         fun inputArgumentOptionalDetectOmission(inputArgumentOptionalDetectOmission: Boolean) = this.apply {
@@ -175,6 +184,7 @@ data class SchemaParserOptions internal constructor(
                 wrappers,
                 allowUnimplementedResolvers,
                 missingResolverDataFetcher,
+                missingResolverDataFetcherProvider,
                 objectMapperProvider,
                 proxyHandlers,
                 inputArgumentOptionalDetectOmission,

--- a/src/main/kotlin/graphql/kickstart/tools/resolver/FieldResolverScanner.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/resolver/FieldResolverScanner.kt
@@ -72,7 +72,9 @@ internal class FieldResolverScanner(val options: SchemaParserOptions) {
     }
 
     private fun missingFieldResolver(field: FieldDefinition, searches: List<Search>, scanProperties: Boolean): FieldResolver {
-        return if (options.allowUnimplementedResolvers || options.missingResolverDataFetcher != null) {
+        return if (options.allowUnimplementedResolvers
+            || options.missingResolverDataFetcher != null
+            || options.missingResolverDataFetcherProvider != null) {
             if (options.allowUnimplementedResolvers) {
                 log.warn("Missing resolver for field: $field")
             }

--- a/src/main/kotlin/graphql/kickstart/tools/resolver/MissingFieldResolver.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/resolver/MissingFieldResolver.kt
@@ -11,8 +11,10 @@ internal class MissingFieldResolver(
     options: SchemaParserOptions
 ) : FieldResolver(field, FieldResolverScanner.Search(Any::class.java, MissingResolverInfo(), null), options, Any::class.java) {
 
-    private val missingResolverDataFetcherProvider: MissingResolverDataFetcherProvider = options.missingResolverDataFetcherProvider ?: MissingResolverDataFetcherProvider { _, options -> options.missingResolverDataFetcher ?: DataFetcher<Any> { TODO("Schema resolver not implemented") } }
-
+    private val missingResolverDataFetcherProvider: MissingResolverDataFetcherProvider = options.missingResolverDataFetcherProvider
+            ?: MissingResolverDataFetcherProvider {
+                _, options -> options.missingResolverDataFetcher ?: DataFetcher<Any> { TODO("Schema resolver not implemented") }
+            }
     override fun scanForMatches(): List<TypeClassMatcher.PotentialMatch> = listOf()
     override fun createDataFetcher(): DataFetcher<*> = missingResolverDataFetcherProvider.createDataFetcher(field, options)
 }

--- a/src/main/kotlin/graphql/kickstart/tools/resolver/MissingFieldResolver.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/resolver/MissingFieldResolver.kt
@@ -11,7 +11,8 @@ internal class MissingFieldResolver(
     options: SchemaParserOptions
 ) : FieldResolver(field, FieldResolverScanner.Search(Any::class.java, MissingResolverInfo(), null), options, Any::class.java) {
 
+    private val missingResolverDataFetcherProvider: MissingResolverDataFetcherProvider = options.missingResolverDataFetcherProvider ?: MissingResolverDataFetcherProvider { _, options -> options.missingResolverDataFetcher ?: DataFetcher<Any> { TODO("Schema resolver not implemented") } }
+
     override fun scanForMatches(): List<TypeClassMatcher.PotentialMatch> = listOf()
-    override fun createDataFetcher(): DataFetcher<*> =
-        options.missingResolverDataFetcher ?: DataFetcher<Any> { TODO("Schema resolver not implemented") }
+    override fun createDataFetcher(): DataFetcher<*> = missingResolverDataFetcherProvider.createDataFetcher(field, options)
 }

--- a/src/main/kotlin/graphql/kickstart/tools/resolver/MissingResolverDataFetcherProvider.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/resolver/MissingResolverDataFetcherProvider.kt
@@ -1,0 +1,14 @@
+package graphql.kickstart.tools.resolver
+
+import graphql.kickstart.tools.SchemaParserOptions
+import graphql.language.FieldDefinition
+import graphql.schema.DataFetcher
+
+/**
+ * Provider for missing resolver data fetchers.
+ */
+fun interface MissingResolverDataFetcherProvider {
+   fun createDataFetcher(field: FieldDefinition,
+                         options: SchemaParserOptions
+    ): DataFetcher<*>
+}

--- a/src/main/kotlin/graphql/kickstart/tools/resolver/MissingResolverDataFetcherProvider.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/resolver/MissingResolverDataFetcherProvider.kt
@@ -8,7 +8,5 @@ import graphql.schema.DataFetcher
  * Provider for missing resolver data fetchers.
  */
 fun interface MissingResolverDataFetcherProvider {
-   fun createDataFetcher(field: FieldDefinition,
-                         options: SchemaParserOptions
-    ): DataFetcher<*>
+   fun createDataFetcher(field: FieldDefinition, options: SchemaParserOptions): DataFetcher<*>
 }

--- a/src/test/kotlin/graphql/kickstart/tools/MissingFieldResolverTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/MissingFieldResolverTest.kt
@@ -2,6 +2,8 @@ package graphql.kickstart.tools
 
 import graphql.GraphQL
 import graphql.kickstart.tools.resolver.FieldResolverError
+import graphql.kickstart.tools.resolver.MissingResolverDataFetcherProvider
+import graphql.language.FieldDefinition
 import graphql.schema.DataFetcher
 import graphql.schema.DataFetchingEnvironment
 import org.junit.Test
@@ -65,9 +67,63 @@ class MissingFieldResolverTest {
         assertEquals(result.getData(), expected)
     }
 
+    @Test
+    fun `should call missing resolver data fetcher provider if provided`() {
+        val missingResolverDataFetcherProvider = TestMissingResolverDataFetcherProvider();
+        val options = SchemaParserOptions.newOptions()
+            .missingResolverDataFetcherProvider(missingResolverDataFetcherProvider)
+            .build();
+        val schema = SchemaParser.newParser()
+            .schemaString(
+                """
+                type Query {
+                    implementedField(input: String): String
+                    missingField(input: Int): Int
+                }
+                """
+            )
+            .resolvers(object : GraphQLQueryResolver {
+                fun implementedField(input: Optional<String>) = input.toString()
+            })
+            .options(options)
+            .build()
+            .makeExecutableSchema()
+
+        val gql = GraphQL.newGraphQL(schema).build()
+
+        val result = gql.execute(
+            """
+            query {
+                implementedField(input: "test-value")
+                missingField(input: 1)
+            }
+            """)
+
+        val expected = mapOf(
+            "implementedField" to "Optional[test-value]",
+            "missingField" to 1
+        )
+
+        assertEquals(result.getData(), expected)
+
+        assertEquals(missingResolverDataFetcherProvider.field?.name, "missingField")
+        assertEquals(missingResolverDataFetcherProvider.options, options)
+    }
+
     class TestMissingResolverDataFetcher : DataFetcher<Any?> {
         override fun get(env: DataFetchingEnvironment?): Any? {
             return env?.getArgument("input")
+        }
+    }
+
+    class TestMissingResolverDataFetcherProvider : MissingResolverDataFetcherProvider {
+        var field: FieldDefinition? = null
+        var options: SchemaParserOptions? = null
+
+        override fun createDataFetcher(field: FieldDefinition, options: SchemaParserOptions): DataFetcher<*> {
+            this.field = field;
+            this.options = options;
+            return TestMissingResolverDataFetcher()
         }
     }
 }

--- a/src/test/kotlin/graphql/kickstart/tools/MissingFieldResolverTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/MissingFieldResolverTest.kt
@@ -70,6 +70,9 @@ class MissingFieldResolverTest {
     @Test
     fun `should call missing resolver data fetcher provider if provided`() {
         val missingResolverDataFetcherProvider = TestMissingResolverDataFetcherProvider();
+        val options = SchemaParserOptions.newOptions()
+                .missingResolverDataFetcherProvider(missingResolverDataFetcherProvider)
+                .build();
         val schema = SchemaParser.newParser()
             .schemaString(
                 """
@@ -82,9 +85,7 @@ class MissingFieldResolverTest {
             .resolvers(object : GraphQLQueryResolver {
                 fun implementedField(input: Optional<String>) = input.toString()
             })
-            .options(SchemaParserOptions.newOptions()
-                    .missingResolverDataFetcherProvider(missingResolverDataFetcherProvider)
-                    .build())
+            .options(options)
             .build()
             .makeExecutableSchema()
 

--- a/src/test/kotlin/graphql/kickstart/tools/MissingFieldResolverTest.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/MissingFieldResolverTest.kt
@@ -70,9 +70,6 @@ class MissingFieldResolverTest {
     @Test
     fun `should call missing resolver data fetcher provider if provided`() {
         val missingResolverDataFetcherProvider = TestMissingResolverDataFetcherProvider();
-        val options = SchemaParserOptions.newOptions()
-            .missingResolverDataFetcherProvider(missingResolverDataFetcherProvider)
-            .build();
         val schema = SchemaParser.newParser()
             .schemaString(
                 """
@@ -85,7 +82,9 @@ class MissingFieldResolverTest {
             .resolvers(object : GraphQLQueryResolver {
                 fun implementedField(input: Optional<String>) = input.toString()
             })
-            .options(options)
+            .options(SchemaParserOptions.newOptions()
+                    .missingResolverDataFetcherProvider(missingResolverDataFetcherProvider)
+                    .build())
             .build()
             .makeExecutableSchema()
 


### PR DESCRIPTION
Provider for creating missing resolver data fetcher to provide options and field definition to factory

<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
Resolves #741

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [X] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [X] New or modified functionality is covered by tests

## Description
Allow missing field resolver data fetcher usage a hook to the field definition and options. Moves away from provide a concrete data fetcher implementation and provide a functional interface (aka Provider) when creating the missing resolver data fetchers and pass the field definition and schema parser options for context.
