### PR TITLE
Upgrade to Java 11

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <java.version>11</java.version>
         <kotlin.version>1.8.21</kotlin.version>
-        <kotlin-coroutines.version>1.6.4</kotlin-coroutines.version>
+        <kotlin-coroutines.version>1.7.3</kotlin-coroutines.version>
         <jackson.version>2.15.2</jackson.version>
         <graphql-java.version>21.0</graphql-java.version>
         <reactive-streams.version>1.0.4</reactive-streams.version>
@@ -134,6 +134,13 @@
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
             <artifactId>kotlin-stdlib</artifactId>
+            <!--TODO remove this after upgrading kotlin-->
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jetbrains</groupId>
+                    <artifactId>annotations</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlin</groupId>
@@ -141,7 +148,7 @@
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-jdk8</artifactId>
+            <artifactId>kotlinx-coroutines-jdk9</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -147,12 +147,12 @@
             <artifactId>kotlin-reflect</artifactId>
         </dependency>
         <dependency>
+            <!--
+            Depending on kotlinx-coroutines-core causes an ambiguous module reference warning.
+            See https://github.com/Kotlin/kotlinx.coroutines/issues/3842
+            -->
             <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-jdk9</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.jetbrains.kotlinx</groupId>
-            <artifactId>kotlinx-coroutines-core</artifactId>
+            <artifactId>kotlinx-coroutines-core-jvm</artifactId>
         </dependency>
         <dependency>
             <groupId>org.jetbrains.kotlinx</groupId>

--- a/src/main/kotlin/module-info.java
+++ b/src/main/kotlin/module-info.java
@@ -1,0 +1,24 @@
+module graphql.java.tools {
+    requires kotlin.stdlib;
+    requires kotlin.reflect;
+    requires kotlinx.coroutines.core;
+    requires kotlinx.coroutines.reactive;
+
+    requires com.graphqljava;
+
+    requires com.fasterxml.jackson.core;
+    requires com.fasterxml.jackson.kotlin;
+    requires com.fasterxml.jackson.databind;
+    requires com.fasterxml.jackson.datatype.jdk8;
+    requires com.fasterxml.classmate;
+
+    requires org.antlr.antlr4.runtime;
+    requires org.apache.commons.lang3;
+    requires org.reactivestreams;
+    requires org.slf4j;
+    requires spring.aop;
+
+    exports graphql.kickstart.tools;
+
+    opens graphql.kickstart.tools to com.fasterxml.jackson.databind;
+}


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
<!-- Resolves #<ISSUE_NUMBER> -->

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description
This should fix deployment issue with javadoc plugin complaining about an unnamed module.
