### PR TITLE
Allow future return type for subscription data fetcher

### DIFF
--- a/src/main/kotlin/graphql/kickstart/tools/resolver/FieldResolverScanner.kt
+++ b/src/main/kotlin/graphql/kickstart/tools/resolver/FieldResolverScanner.kt
@@ -138,7 +138,7 @@ internal class FieldResolverScanner(val options: SchemaParserOptions) {
             && method.genericReturnType is ParameterizedType
             && (method.genericReturnType as ParameterizedType).actualTypeArguments
             .any {
-                it is ParameterizedType && it.rawType == Publisher::class.java
+                it is ParameterizedType && it.unwrap().isAssignableFrom(Publisher::class.java)
             }
 
     private fun receiveChannelToPublisherWrapper(method: Method) =

--- a/src/test/kotlin/graphql/kickstart/tools/EndToEndSpecHelper.kt
+++ b/src/test/kotlin/graphql/kickstart/tools/EndToEndSpecHelper.kt
@@ -123,6 +123,7 @@ type Mutation {
 
 type Subscription {
     onItemCreated: Item!
+    onItemCreatedFuture: Item!
     onItemCreatedCoroutineChannel: Item!
     onItemCreatedCoroutineChannelAndSuspendFunction: Item!
 }
@@ -373,13 +374,20 @@ class Subscription : GraphQLSubscriptionResolver {
     fun onItemCreated(env: DataFetchingEnvironment) =
         Publisher<Item> { subscriber ->
             subscriber.onNext(env.graphQlContext["newItem"])
-//            subscriber.onComplete()
         }
 
     fun onItemCreatedCoroutineChannel(env: DataFetchingEnvironment): ReceiveChannel<Item> {
         val channel = Channel<Item>(1)
         channel.trySend(env.graphQlContext["newItem"])
         return channel
+    }
+
+    fun onItemCreatedFuture(env: DataFetchingEnvironment): CompletableFuture<Publisher<Item>> {
+        return CompletableFuture.supplyAsync {
+            Publisher<Item> { subscriber ->
+                subscriber.onNext(env.graphQlContext["newItem"])
+            }
+        }
     }
 
     suspend fun onItemCreatedCoroutineChannelAndSuspendFunction(env: DataFetchingEnvironment): ReceiveChannel<Item> {


### PR DESCRIPTION
<!-- Uncomment one of the following lines as necessary. -->
<!-- Fixes #<ISSUE_NUMBER> -->
<!-- Resolves #<ISSUE_NUMBER> -->

Fix oversight from https://github.com/graphql-java-kickstart/graphql-java-tools/pull/756. Allow subscription data resolvers to also return a `CompletableFuture<Publisher>`.

## Checklist
<!-- Change [ ] to [x] to indicate you acknowledge the check. -->
- [x] Pull requests follows the [contribution guide](https://github.com/graphql-java-kickstart/graphql-java-tools/wiki/Contribution-guide)
- [x] New or modified functionality is covered by tests

## Description
<!-- Briefly describe how you resolved the issue or a bug. -->
